### PR TITLE
feat(screenshot): Add compare_layout_screenshots tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.0
+
+- Added the `compare_layout_screenshots` tool to capture, verify, and highlight visual differences in layout screens.
+- Added parameters to select the capture type (`device` or `skia`) and specify target devices.
+
 ## 1.0.0
 
 - Initial version.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ All tools require an active connection to a running application, unless stated o
 | Tool Name | Parameters | Description |
 | :--- | :--- | :--- |
 | `inspect_layout_constraints` / `inspect_widget` | `widget_id` (required, or `widgetId` for alias) | Inspect parent constraints, render size, and diagnostics of a widget. |
+| `compare_layout_screenshots` | `baseline_name` (required), `action` (required), `threshold` (optional) | Capture screenshots and run pixel diff comparison to detect visual changes. |
 | `toggle_widget_selection` | `enabled` (required) | Toggle the on-device widget selection overlay. |
 | `toggle_package_widgets` | `enabled` (required) | Configure whether third-party packages appear in the inspector tree. |
 | `toggle_layout_guidelines` / `toggle_debug_paint` | `enabled` (required) | Toggle layout guidelines (debug paint) on the device. |

--- a/lib/flutter_agent_lens.dart
+++ b/lib/flutter_agent_lens.dart
@@ -6,6 +6,7 @@ import 'package:stream_channel/stream_channel.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:vm_service/vm_service_io.dart';
 import 'package:path/path.dart' as p;
+import 'package:image/image.dart' as img;
 
 import 'src/path_resolver.dart';
 import 'src/port_discovery.dart';
@@ -20,6 +21,7 @@ part 'src/handlers/debugger_handlers.dart';
 
 part 'src/handlers/bundle_handlers.dart';
 part 'src/handlers/deeplink_handlers.dart';
+part 'src/handlers/screenshot_handlers.dart';
 
 /// Flutter Agent Lens MCP Server.
 final class FlutterAgentLensServer extends MCPServer with ToolsSupport {
@@ -35,6 +37,7 @@ final class FlutterAgentLensServer extends MCPServer with ToolsSupport {
         );
 
   VmService? _vmService;
+  String? _vmServiceUri;
   String? _isolateId;
   String? _workspaceRoot;
   PathResolver? _pathResolver;
@@ -708,6 +711,35 @@ final class FlutterAgentLensServer extends MCPServer with ToolsSupport {
         ),
       ),
       _handleToggleLayoutGuidelines,
+    );
+
+    // Compare Layout Screenshots
+    registerTool(
+      Tool(
+        name: 'compare_layout_screenshots',
+        description: 'Capture screenshots and perform pixel diff checks to find layout changes or bugs.',
+        inputSchema: ObjectSchema(
+          properties: {
+            'baseline_name': StringSchema(
+              description: 'The filename prefix for the baseline screenshot (e.g. "home_screen").',
+            ),
+            'action': StringSchema(
+              description: 'The visual operation to execute (capture_baseline, compare).',
+            ),
+            'threshold': NumberSchema(
+              description: 'The similarity pass threshold from 0.0 to 1.0 (default: 0.98).',
+            ),
+            'screenshot_type': StringSchema(
+              description: 'The format/method to capture (device = native screenshot, skia = Skia Picture via VM service; default: device).',
+            ),
+            'device_id': StringSchema(
+              description: 'Target device ID or name if multiple devices are connected (prefixes allowed).',
+            ),
+          },
+          required: ['baseline_name', 'action'],
+        ),
+      ),
+      _handleCompareLayoutScreenshots,
     );
   }
 

--- a/lib/flutter_agent_lens.dart
+++ b/lib/flutter_agent_lens.dart
@@ -30,7 +30,7 @@ final class FlutterAgentLensServer extends MCPServer with ToolsSupport {
           channel,
           implementation: Implementation(
             name: 'flutter_agent_lens',
-            version: '1.0.0',
+            version: '1.1.0',
           ),
           instructions: 'A tool server to interact with running Flutter apps. '
               'Connect using the connect tool, or discover running apps with discover_apps.',

--- a/lib/src/handlers/connection_handlers.dart
+++ b/lib/src/handlers/connection_handlers.dart
@@ -7,6 +7,7 @@ extension ConnectionHandlers on FlutterAgentLensServer {
       final uri =
           (req.arguments!['uri'] ?? req.arguments!['vmServiceUri']) as String;
       stderr.writeln('[mcp:connect] Attempting connection to: $uri');
+      _vmServiceUri = uri;
       _workspaceRoot = req.arguments?['workspace_root'] as String?;
 
       if (_workspaceRoot != null) {
@@ -235,6 +236,7 @@ extension ConnectionHandlers on FlutterAgentLensServer {
       await _vmService!.dispose();
     } catch (_) {}
     _vmService = null;
+    _vmServiceUri = null;
     _isolateId = null;
     return CallToolResult(
       content: [TextContent(text: 'Disconnected from Flutter app.')],

--- a/lib/src/handlers/screenshot_handlers.dart
+++ b/lib/src/handlers/screenshot_handlers.dart
@@ -1,0 +1,210 @@
+part of '../../flutter_agent_lens.dart';
+
+/// Extension containing handlers for capturing and comparing layout screenshots.
+extension ScreenshotHandlers on FlutterAgentLensServer {
+  Future<CallToolResult> _handleCompareLayoutScreenshots(CallToolRequest req) async {
+    final root = _workspaceRoot;
+    if (root == null || root.isEmpty) {
+      return CallToolResult(
+        content: [TextContent(text: 'Workspace root is not configured. Run connect_to_app first to set it.')],
+        isError: true,
+      );
+    }
+
+    final baselineName = req.arguments!['baseline_name'] as String;
+    final action = req.arguments!['action'] as String;
+    final threshold = (req.arguments?['threshold'] as num?)?.toDouble() ?? 0.98;
+    final screenshotType = req.arguments?['screenshot_type'] as String? ?? 'device';
+    final deviceId = req.arguments?['device_id'] as String?;
+
+    if (action != 'capture_baseline' && action != 'compare') {
+      return CallToolResult(
+        content: [TextContent(text: 'Invalid action. Supported actions: capture_baseline, compare.')],
+        isError: true,
+      );
+    }
+    if (screenshotType != 'device' && screenshotType != 'skia') {
+      return CallToolResult(
+        content: [TextContent(text: 'Invalid screenshot_type. Supported values: device, skia.')],
+        isError: true,
+      );
+    }
+
+    stderr.writeln(
+        '[mcp:screenshot] Action=$action, baselineName=$baselineName, type=$screenshotType, deviceId=$deviceId');
+
+    try {
+      final screenshotDir = Directory(p.join(root, 'build', 'mcp_screenshots'));
+      if (!screenshotDir.existsSync()) {
+        screenshotDir.createSync(recursive: true);
+      }
+
+      final flutterRoot = Platform.environment['FLUTTER_ROOT'];
+      final executable = flutterRoot != null
+          ? p.join(flutterRoot, 'bin', Platform.isWindows ? 'flutter.bat' : 'flutter')
+          : (Platform.isWindows ? 'flutter.bat' : 'flutter');
+
+      if (action == 'capture_baseline') {
+        final baselinePath = p.join(screenshotDir.path, '${baselineName}_baseline.png');
+        stderr.writeln('[mcp:screenshot] Capturing baseline to $baselinePath');
+
+        final args = [
+          'screenshot',
+          '--out=$baselinePath',
+          if (screenshotType == 'skia' && _vmServiceUri != null) ...[
+            '--vm-service-url=$_vmServiceUri',
+            '--type=skia',
+          ] else ...[
+            '--type=device',
+          ],
+          if (deviceId != null && deviceId.isNotEmpty) ...[
+            '--device-id=$deviceId',
+          ],
+        ];
+
+        final result = await Process.run(executable, args);
+        if (result.exitCode != 0) {
+          return CallToolResult(
+            content: [
+              TextContent(
+                text: 'Failed to capture baseline screenshot (Exit Code ${result.exitCode}):\n${result.stderr}',
+              )
+            ],
+            isError: true,
+          );
+        }
+
+        return CallToolResult(
+          content: [
+            TextContent(text: 'Successfully captured and saved baseline screenshot to $baselinePath')
+          ],
+        );
+      } else {
+        // Compare action
+        final baselinePath = p.join(screenshotDir.path, '${baselineName}_baseline.png');
+        final currentPath = p.join(screenshotDir.path, '${baselineName}_current.png');
+        final diffPath = p.join(screenshotDir.path, '${baselineName}_diff.png');
+
+        if (!File(baselinePath).existsSync()) {
+          return CallToolResult(
+            content: [
+              TextContent(text: 'Baseline screenshot not found for "$baselineName". Run capture_baseline first.')
+            ],
+            isError: true,
+          );
+        }
+
+        stderr.writeln('[mcp:screenshot] Capturing current screen to $currentPath');
+        final args = [
+          'screenshot',
+          '--out=$currentPath',
+          if (screenshotType == 'skia' && _vmServiceUri != null) ...[
+            '--vm-service-url=$_vmServiceUri',
+            '--type=skia',
+          ] else ...[
+            '--type=device',
+          ],
+          if (deviceId != null && deviceId.isNotEmpty) ...[
+            '--device-id=$deviceId',
+          ],
+        ];
+
+        final result = await Process.run(executable, args);
+        if (result.exitCode != 0) {
+          return CallToolResult(
+            content: [
+              TextContent(
+                text: 'Failed to capture comparison screenshot (Exit Code ${result.exitCode}):\n${result.stderr}',
+              )
+            ],
+            isError: true,
+          );
+        }
+
+        stderr.writeln('[mcp:screenshot] Loading images for pixel diff...');
+        final baselineBytes = await File(baselinePath).readAsBytes();
+        final currentBytes = await File(currentPath).readAsBytes();
+
+        final img1 = img.decodePng(baselineBytes);
+        final img2 = img.decodePng(currentBytes);
+
+        if (img1 == null || img2 == null) {
+          return CallToolResult(
+            content: [TextContent(text: 'Failed to decode screenshots. Ensure the captured files are valid PNGs.')],
+            isError: true,
+          );
+        }
+
+        if (img1.width != img2.width || img1.height != img2.height) {
+          return CallToolResult(
+            content: [
+              TextContent(
+                text: 'Layout size mismatch: Baseline is ${img1.width}x${img1.height}, '
+                    'but current screen is ${img2.width}x${img2.height}.',
+              )
+            ],
+            isError: true,
+          );
+        }
+
+        var matchingPixels = 0;
+        final totalPixels = img1.width * img1.height;
+        final diffImage = img.Image(width: img1.width, height: img1.height);
+
+        for (var y = 0; y < img1.height; y++) {
+          for (var x = 0; x < img1.width; x++) {
+            final p1 = img1.getPixel(x, y);
+            final p2 = img2.getPixel(x, y);
+
+            if (p1.r == p2.r && p1.g == p2.g && p1.b == p2.b) {
+              matchingPixels++;
+              diffImage.setPixel(x, y, p2);
+            } else {
+              // Mark difference in bright red
+              diffImage.setPixel(x, y, img.ColorRgba8(255, 0, 0, 255));
+            }
+          }
+        }
+
+        final similarity = matchingPixels / totalPixels;
+        final passed = similarity >= threshold;
+
+        stderr.writeln('[mcp:screenshot] Saving diff image to $diffPath');
+        await File(diffPath).writeAsBytes(img.encodePng(diffImage));
+
+        final md = StringBuffer('### Layout Screenshot Comparison: `$baselineName`\n\n');
+        md.writeln('- **Status**: ${passed ? "✅ PASS" : "❌ FAIL"}');
+        md.writeln('- **Similarity Score**: ${(similarity * 100).toStringAsFixed(2)}% (Threshold: ${(threshold * 100).toStringAsFixed(2)}%)');
+        md.writeln('- **Matching Pixels**: $matchingPixels / $totalPixels');
+        md.writeln();
+        md.writeln('#### Files Generated:');
+        md.writeln('- Baseline: `$baselinePath`');
+        md.writeln('- Current: `$currentPath`');
+        md.writeln('- Visual Diff: `$diffPath`');
+
+        return _serializeDualFormat(
+          title: '### Visual Layout Comparison Report',
+          markdownBody: md.toString(),
+          structuredData: {
+            'baseline_name': baselineName,
+            'similarity_ratio': similarity,
+            'threshold': threshold,
+            'passed': passed,
+            'total_pixels': totalPixels,
+            'matching_pixels': matchingPixels,
+            'baseline_path': baselinePath,
+            'current_path': currentPath,
+            'diff_path': diffPath,
+          },
+        );
+      }
+    } catch (e, st) {
+      stderr.writeln('[mcp:screenshot] ERROR: $e');
+      stderr.writeln('[mcp:screenshot] STACKTRACE: $st');
+      return CallToolResult(
+        content: [TextContent(text: 'Layout screenshot comparison failed: $e')],
+        isError: true,
+      );
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "13.0.0"
+  archive:
+    dependency: transitive
+    description:
+      name: archive
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.9"
   args:
     dependency: "direct main"
     description:
@@ -89,6 +97,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   file:
     dependency: transitive
     description:
@@ -129,6 +145,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  image:
+    dependency: "direct main"
+    description:
+      name: image
+      sha256: "6300175e00616bbc832e2fc91bfa4d776af5402c81c7151bee6905bb08473c52"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.9.1"
   io:
     dependency: transitive
     description:
@@ -209,6 +233,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
   pool:
     dependency: transitive
     description:
@@ -217,6 +249,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
   pub_semver:
     dependency: transitive
     description:
@@ -401,6 +441,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "67f0aff7be013d107995e9b75bf4e7f2c3ef2dfdb2c8e68024bba0a7fd5756a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   yaml:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   stream_channel: ^2.1.4
   vm_service: ^15.2.0
   path: ^1.9.1
+  image: ^4.9.1
 
 dev_dependencies:
   lints: 6.1.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_agent_lens
 description: Agent-first MCP server to debug, profile, and optimize running Flutter apps.
-version: 1.0.0
+version: 1.1.0
 homepage: https://github.com/dhruvanbhalara/flutter_agent_lens
 repository: https://github.com/dhruvanbhalara/flutter_agent_lens
 


### PR DESCRIPTION
Add compare_layout_screenshots tool

This pull request implements the `compare_layout_screenshots` tool for layout verification and visual regression testing in Flutter applications. The tool captures screenshots and executes a pixel-by-pixel comparison against saved baseline screenshots, highlighting visual discrepancies in red.

The tool exposes `screenshot_type` (supporting `device` or `skia` modes) and `device_id` parameters to target specific active emulators or devices.

This PR also updates the package version to `1.1.0` and updates the CHANGELOG.md file with version details.