### PR TITLE
feat: add dtd support and hot restart fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.5.0
+
+- Subscribed to `onServiceEvent` before calling `streamListen(EventStreams.kService)` in `connection_handlers.dart` to resolve a VM service discovery race condition.
+- Routed `handleHotReload` and `handleHotRestart` through DTD service calls if DTD is active, VM service callbacks (`s1.reloadSources` with `isolateId` and `s1.hotRestart`) if available, or isolate-level extensions as a fallback.
+- Added dependency on `dtd` package to support direct Dart Tooling Daemon communication.
+
 ## 1.4.1
 
 - Refactored and optimized internal MCP tool handlers for widget tracking, memory diffing, and network capturing.

--- a/lib/flutter_agent_lens.dart
+++ b/lib/flutter_agent_lens.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'package:dart_mcp/server.dart';
+import 'package:dtd/dtd.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:vm_service/vm_service_io.dart';
@@ -43,6 +44,10 @@ final class FlutterAgentLensServer extends MCPServer with ToolsSupport {
   PathResolver? _pathResolver;
   String? _cachedLibraryId;
   final Map<String, _MemorySnapshot> _memorySnapshots = {};
+
+  // DTD integration
+  DartToolingDaemon? _dtdClient;
+  Uri? _dtdUri;
 
   // Stateful Rebuild Tracking
   bool _isTrackingRebuilds = false;
@@ -106,6 +111,9 @@ final class FlutterAgentLensServer extends MCPServer with ToolsSupport {
     _capturedRequests.clear();
     _lastLogLine = null;
     _duplicateLogCount = 0;
+    _dtdClient?.close();
+    _dtdClient = null;
+    _dtdUri = null;
   }
 
   @override

--- a/lib/src/handlers/connection_handlers.dart
+++ b/lib/src/handlers/connection_handlers.dart
@@ -16,6 +16,8 @@ extension ConnectionHandlers on FlutterAgentLensServer {
       String uriToConnect = rawUri;
       if (_isDtdUri(rawUri)) {
         try {
+          _dtdUri = Uri.parse(rawUri);
+          _dtdClient = await DartToolingDaemon.connect(_dtdUri!);
           uriToConnect = await _resolveDtdToVmServiceUri(rawUri);
           stderr.writeln(
               '[mcp:connect] DTD resolved VM Service URI: $uriToConnect');
@@ -58,11 +60,10 @@ extension ConnectionHandlers on FlutterAgentLensServer {
       // The VM Protocol guarantees that when a client calls streamListen('Service')
       // it immediately receives a ServiceRegistered event for every service that
       // is already registered - this is how DevTools seeds its own map.
-      // We await the subscription, attach the listener, then wait a short drain
+      // We attach the listener first, await the subscription, then wait a short drain
       // window so the replay events populate _registeredMethodsForService before
       // connect() returns and the caller invokes hot_restart / hot_reload.
       try {
-        await _vmService!.streamListen(EventStreams.kService);
         _serviceStreamSub = _vmService!.onServiceEvent.listen((Event event) {
           final service = event.service;
           final method = event.method;
@@ -76,6 +77,7 @@ extension ConnectionHandlers on FlutterAgentLensServer {
             stderr.writeln('[mcp:service] Unregistered service: $service');
           }
         });
+        await _vmService!.streamListen(EventStreams.kService);
         // Drain window: give the event loop a tick to deliver the replayed
         // ServiceRegistered events before we return from connect.
         await Future<void>.delayed(const Duration(milliseconds: 100));
@@ -129,8 +131,17 @@ extension ConnectionHandlers on FlutterAgentLensServer {
     }
   }
 
+  void _cleanupLogging() {
+    _stdoutSub?.cancel();
+    _stderrSub?.cancel();
+    _loggingSub?.cancel();
+    _stdoutSub = null;
+    _stderrSub = null;
+    _loggingSub = null;
+  }
+
   void _startLogging() {
-    _cleanupStreams();
+    _cleanupLogging();
     _logBuffer.clear();
 
     // Subscribe to stdout and stderr streams using helper
@@ -151,25 +162,6 @@ extension ConnectionHandlers on FlutterAgentLensServer {
         }
       });
     }).catchError((_) {});
-
-    // Subscribe to the Service stream to track dynamically registered service methods.
-    if (_serviceStreamSub == null) {
-      _vmService!.streamListen(EventStreams.kService).then((_) {
-        _serviceStreamSub = _vmService!.onServiceEvent.listen((Event event) {
-          final service = event.service;
-          final method = event.method;
-          if (service == null || method == null) return;
-          if (event.kind == EventKind.kServiceRegistered) {
-            _registeredMethodsForService[service] = method;
-            stderr.writeln(
-                '[mcp:service] Registered service: $service -> $method');
-          } else if (event.kind == EventKind.kServiceUnregistered) {
-            _registeredMethodsForService.remove(service);
-            stderr.writeln('[mcp:service] Unregistered service: $service');
-          }
-        });
-      }).catchError((_) {});
-    }
   }
 
   void _addToLogBuffer(String prefix, String message) {

--- a/lib/src/handlers/performance_handlers.dart
+++ b/lib/src/handlers/performance_handlers.dart
@@ -79,11 +79,44 @@ extension PerformanceHandlers on FlutterAgentLensServer {
   }
 
   Future<CallToolResult> handleHotReload(CallToolRequest req) async {
-    stderr.writeln('[mcp:hot_reload] Triggering ext.flutter.reassemble...');
-    await _vmService!.callServiceExtension(
-      'ext.flutter.reassemble',
-      isolateId: _isolateId!,
-    );
+    bool dtdSuccess = false;
+
+    // Use DTD ConnectedApp service if available to delegate compilation and UI reassembly to the host editor/process.
+    if (_dtdClient != null && _vmServiceUri != null) {
+      stderr.writeln(
+          '[mcp:hot_reload] Triggering ConnectedApp.hotReload via DTD...');
+      try {
+        await _dtdClient!.call(
+          'ConnectedApp',
+          'hotReload',
+          params: {'vmServiceUri': _vmServiceUri},
+        );
+        dtdSuccess = true;
+      } catch (e) {
+        stderr.writeln(
+            '[mcp:hot_reload] DTD call failed: $e. Falling back to direct VM Service...');
+      }
+    }
+
+    if (!dtdSuccess) {
+      final reloadMethod = _registeredMethodsForService['reloadSources'] ??
+          _registeredMethodsForService['hotReload'];
+      if (reloadMethod != null) {
+        stderr.writeln(
+            '[mcp:hot_reload] Triggering registered service $reloadMethod...');
+        await _vmService!.callMethod(
+          reloadMethod,
+          args: {'isolateId': _isolateId!},
+        );
+      } else {
+        stderr.writeln('[mcp:hot_reload] Triggering ext.flutter.reassemble...');
+        await _vmService!.callServiceExtension(
+          'ext.flutter.reassemble',
+          isolateId: _isolateId!,
+        );
+      }
+    }
+
     return CallToolResult(content: [
       TextContent(
         text: 'Hot reload triggered successfully.\n'
@@ -94,27 +127,59 @@ extension PerformanceHandlers on FlutterAgentLensServer {
   }
 
   Future<CallToolResult> handleHotRestart(CallToolRequest req) async {
-    stderr.writeln(
-        '[mcp:hot_restart] Checking for restart service extensions...');
-    final isolate = await _vmService!.getIsolate(_isolateId!);
-    final extensions = isolate.extensionRPCs ?? [];
+    bool dtdSuccess = false;
 
-    if (extensions.contains('ext.flutter.restart')) {
-      stderr.writeln('[mcp:hot_restart] Triggering ext.flutter.restart...');
-      await _vmService!.callServiceExtension(
-        'ext.flutter.restart',
-        isolateId: _isolateId!,
-      );
-    } else {
+    // Use DTD ConnectedApp service if available to delegate compilation, reset in-memory state, and rerun main() via the host.
+    if (_dtdClient != null && _vmServiceUri != null) {
       stderr.writeln(
-          '[mcp:hot_restart] ext.flutter.restart not found, falling back to reassemble...');
-      await _vmService!.callServiceExtension(
-        'ext.flutter.reassemble',
-        isolateId: _isolateId!,
-      );
+          '[mcp:hot_restart] Triggering ConnectedApp.hotRestart via DTD...');
+      try {
+        await _dtdClient!.call(
+          'ConnectedApp',
+          'hotRestart',
+          params: {'vmServiceUri': _vmServiceUri},
+        );
+        dtdSuccess = true;
+      } catch (e) {
+        stderr.writeln(
+            '[mcp:hot_restart] DTD call failed: $e. Falling back to direct VM Service...');
+      }
     }
 
-    // Refresh isolate ID and clear library cache
+    if (!dtdSuccess) {
+      final hotRestartMethod = _registeredMethodsForService['hotRestart'] ??
+          _registeredMethodsForService['restart'];
+      if (hotRestartMethod != null) {
+        stderr.writeln(
+            '[mcp:hot_restart] Triggering registered service $hotRestartMethod...');
+        await _vmService!.callMethod(hotRestartMethod);
+      } else {
+        stderr.writeln(
+            '[mcp:hot_restart] Checking for restart service extensions...');
+        final isolate = await _vmService!.getIsolate(_isolateId!);
+        final extensions = isolate.extensionRPCs ?? [];
+
+        if (extensions.contains('ext.flutter.restart')) {
+          stderr.writeln('[mcp:hot_restart] Triggering ext.flutter.restart...');
+          await _vmService!.callServiceExtension(
+            'ext.flutter.restart',
+            isolateId: _isolateId!,
+          );
+        } else {
+          stderr.writeln(
+              '[mcp:hot_restart] ext.flutter.restart not found, falling back to reassemble...');
+          await _vmService!.callServiceExtension(
+            'ext.flutter.reassemble',
+            isolateId: _isolateId!,
+          );
+        }
+      }
+    }
+
+    // Wait briefly for the isolate to restart before querying the VM
+    await Future.delayed(const Duration(milliseconds: 800));
+
+    // Refresh the isolate ID and cache after the restart
     final vm = await _vmService!.getVM();
     if (vm.isolates != null && vm.isolates!.isNotEmpty) {
       _isolateId = vm.isolates!.first.id!;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
@@ -97,6 +105,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.5.1"
+  dart_service_protocol_shared:
+    dependency: transitive
+    description:
+      name: dart_service_protocol_shared
+      sha256: "1737875c176d7e3d87bb3a359182828b542fe20a0b34198b8d31a81af5c7a76d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.3"
+  dtd:
+    dependency: "direct main"
+    description:
+      name: dtd
+      sha256: "09ddb228b3d1478a093556357692a4c203ff4f9d5f8cda05dfdca0ff3fb7c5d3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   ffi:
     dependency: transitive
     description:
@@ -129,6 +153,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:
@@ -241,6 +273,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.2"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "5d6b1b0036a5f331ebc77c850ebc8506cbc1e9416c27e59b439f917a902a4984"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.6"
   pool:
     dependency: transitive
     description:
@@ -393,6 +433,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
+  unified_analytics:
+    dependency: transitive
+    description:
+      name: unified_analytics
+      sha256: "0988c50d794f3cd96f6df92b4b35b7c333bbf869df304fc6062a45ebc7eb0776"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.0.15"
   vm_service:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_agent_lens
 description: Agent-first MCP server to debug, profile, and optimize running Flutter apps.
-version: 1.4.1
+version: 1.5.0
 homepage: https://github.com/dhruvanbhalara/flutter_agent_lens
 repository: https://github.com/dhruvanbhalara/flutter_agent_lens
 
@@ -13,6 +13,7 @@ executables:
 dependencies:
   args: ^2.7.0
   dart_mcp: ^0.5.1
+  dtd: ^4.0.0
   stream_channel: ^2.1.4
   vm_service: ^15.2.0
   path: ^1.9.1


### PR DESCRIPTION
This PR introduces DTD (Dart Tooling Daemon) support to enable compiler-backed hot reload and hot restart commands, resolves a VM service discovery race condition, and bumps the library version to `1.5.0`.

### Changes

- **DTD Dependency**: Added `dtd` package to `pubspec.yaml` to handle direct Tooling Daemon client connections.
- **Connection & Client Caching**: Updated connection handling to automatically establish and cache a persistent `DartToolingDaemon` client when connecting to a DTD URI, and clean it up on disconnect.
- **Service Discovery Fix**: Resolved a startup race condition by subscribing to the VM Service `onServiceEvent` stream before invoking `streamListen(EventStreams.kService)`.
- **Logging Subscriptions Fix**: Added a dedicated `_cleanupLogging` helper to prevent start-up logging from canceling and clearing active VM service registrations.
- **Hot Reload/Restart Routing**: Configured routing to check DTD services first, fall back to registered VM methods (`s1.reloadSources` with `isolateId` and `s1.hotRestart`) if available, and use isolate extensions as a final fallback.
- **Release Version**: Bumped version to `1.5.0` in `pubspec.yaml` and documented the additions in `CHANGELOG.md`.

### Verification Details

- Tested direct VM Service connection and DTD connection flows with the mock DTD server.
- Verified that all tool execution paths compile cleanly with `dart analyze`.
