### PR TITLE
fix(mcp): filter system isolates and recover from sentinel/collected errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
+## 1.5.3
+
+- Filtered out system isolates when connecting to the VM service to avoid selecting non-user code.
+- Implemented automatic recovery and retry logic when encountering sentinel or collected isolate ID errors.
+
 ## 1.5.2
 
 - Deprecated and removed the redundant `dual` format option across all tools to optimize token usage.
-- Updated tool schemas and `test_all_tools.dart` to specify either `markdown` or `json`.
 
 ## 1.5.1
 

--- a/lib/flutter_agent_lens.dart
+++ b/lib/flutter_agent_lens.dart
@@ -38,7 +38,7 @@ final class FlutterAgentLensServer extends MCPServer
           channel,
           implementation: Implementation(
             name: 'flutter_agent_lens',
-            version: '1.5.2',
+            version: '1.5.3',
           ),
           instructions: 'A tool server to interact with running Flutter apps. '
               'Connect using the connect tool, or discover running apps with discover_apps.',

--- a/lib/src/mixins/connection_support.dart
+++ b/lib/src/mixins/connection_support.dart
@@ -177,7 +177,13 @@ base mixin ConnectionSupport
           isError: true,
         );
       }
-      isolateId = vm.isolates!.first.id!;
+      final activeIsolates =
+          vm.isolates!.where((i) => i.isSystemIsolate != true).toList();
+      if (activeIsolates.isNotEmpty) {
+        isolateId = activeIsolates.first.id!;
+      } else {
+        isolateId = vm.isolates!.first.id!;
+      }
       final ver = await vmService!.getVersion();
 
       try {

--- a/lib/src/mixins/vm_connection_support.dart
+++ b/lib/src/mixins/vm_connection_support.dart
@@ -51,12 +51,35 @@ base mixin VmConnectionSupport on MCPServer, ToolsSupport {
     bool requiresConnection = true,
   }) {
     return (CallToolRequest req) async {
+      if (requiresConnection && vmService != null && isolateId == null) {
+        await refreshIsolateId();
+      }
       if (requiresConnection && (vmService == null || isolateId == null)) {
         return notConnected();
       }
       try {
         return await handler(req);
       } catch (e, st) {
+        if (requiresConnection && _isCollectedError(e)) {
+          stderr.writeln(
+              '[mcp:$toolName] Detected collected/sentinel error, attempting to refresh isolate ID and retry...');
+          final refreshed = await refreshIsolateId();
+          if (refreshed) {
+            try {
+              return await handler(req);
+            } catch (retryErr, retrySt) {
+              stderr.writeln('[mcp:$toolName] Retry failed: $retryErr');
+              stderr.writeln('[mcp:$toolName] STACKTRACE: $retrySt');
+              return CallToolResult(
+                content: [
+                  TextContent(
+                      text: '$toolName execution failed (retry): $retryErr')
+                ],
+                isError: true,
+              );
+            }
+          }
+        }
         stderr.writeln('[mcp:$toolName] ERROR: $e');
         stderr.writeln('[mcp:$toolName] STACKTRACE: $st');
         return CallToolResult(
@@ -65,6 +88,36 @@ base mixin VmConnectionSupport on MCPServer, ToolsSupport {
         );
       }
     };
+  }
+
+  bool _isCollectedError(Object e) {
+    final str = e.toString();
+    return str.contains('Collected') ||
+        str.contains('Sentinel') ||
+        str.contains('sentinel');
+  }
+
+  Future<bool> refreshIsolateId() async {
+    if (vmService == null) return false;
+    try {
+      final vm = await vmService!.getVM();
+      if (vm.isolates != null && vm.isolates!.isNotEmpty) {
+        final activeIsolates =
+            vm.isolates!.where((i) => i.isSystemIsolate != true).toList();
+        if (activeIsolates.isNotEmpty) {
+          isolateId = activeIsolates.first.id;
+        } else {
+          isolateId = vm.isolates!.first.id;
+        }
+        cachedLibraryId = null;
+        stderr.writeln(
+            '[mcp] Dynamically refreshed active isolate ID: $isolateId');
+        return true;
+      }
+    } catch (err) {
+      stderr.writeln('[mcp] Failed to refresh isolate ID: $err');
+    }
+    return false;
   }
 
   CallToolResult serializeDualFormat({

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_agent_lens
 description: Agent-first MCP server to debug, profile, and optimize running Flutter apps.
-version: 1.5.2
+version: 1.5.3
 homepage: https://github.com/dhruvanbhalara/flutter_agent_lens
 repository: https://github.com/dhruvanbhalara/flutter_agent_lens
 


### PR DESCRIPTION
### Commits Summary

1. **fix(mcp): filter system isolates and recover from sentinel/collected errors**
   - Filters out system isolates (like the Service Isolate) when connecting to the VM service.
   - Adds automatic recovery and retry logic when encountering sentinel or collected isolate ID errors during tool execution.

2. **chore: bump version to 1.5.3**
   - Bumps the version to `1.5.3` in `pubspec.yaml` and the server implementation.
   - Updates `CHANGELOG.md` with release notes for version `1.5.3`.