### PR TITLE
fix: add connection safety guards, timeouts, and error logging

### DIFF
--- a/lib/src/mixins/bundle_analysis_support.dart
+++ b/lib/src/mixins/bundle_analysis_support.dart
@@ -9,8 +9,7 @@ base mixin BundleAnalysisSupport
     on MCPServer, ToolsSupport, VmConnectionSupport {
   void registerBundleAnalysisTools() {
     final formatSchema = StringSchema(
-      description:
-          'Response format: markdown or json (default: markdown).',
+      description: 'Response format: markdown or json (default: markdown).',
     );
 
     registerTool(
@@ -64,7 +63,10 @@ base mixin BundleAnalysisSupport
         } else if (os == 'linux') {
           defaultTarget = 'linux';
         }
-      } catch (_) {}
+      } catch (e) {
+        stderr.writeln(
+            '[mcp:bundle_size] Error auto-detecting target OS from VM: $e');
+      }
     }
 
     final target = req.arguments?['build_target'] as String? ?? defaultTarget;

--- a/lib/src/mixins/connection_support.dart
+++ b/lib/src/mixins/connection_support.dart
@@ -217,12 +217,17 @@ base mixin ConnectionSupport
         );
       } catch (_) {}
 
+      final selectedIsolateName = vm.isolates!
+          .firstWhere((i) => i.id == isolateId,
+              orElse: () => vm.isolates!.first)
+          .name;
+
       return CallToolResult(
         content: [
           TextContent(
               text: 'Successfully connected to VM Service.\n'
                   '- VM version: ${ver.major}.${ver.minor}\n'
-                  '- Main Isolate: ${vm.isolates!.first.name} ($isolateId)\n'
+                  '- Main Isolate: $selectedIsolateName ($isolateId)\n'
                   '- Workspace Root configured: ${workspaceRoot ?? "None"}')
         ],
       );

--- a/lib/src/mixins/connection_support.dart
+++ b/lib/src/mixins/connection_support.dart
@@ -19,8 +19,7 @@ base mixin ConnectionSupport
         RootsTrackingSupport {
   void registerConnectionTools() {
     final formatSchema = StringSchema(
-      description:
-          'Response format: markdown or json (default: markdown).',
+      description: 'Response format: markdown or json (default: markdown).',
     );
 
     registerTool(
@@ -268,6 +267,9 @@ base mixin ConnectionSupport
   }
 
   Future<CallToolResult> _handleGetAppInfo(CallToolRequest req) async {
+    if (vmService == null || isolateId == null) {
+      return notConnected();
+    }
     final vm = await vmService!.getVM();
     final isolate = await vmService!.getIsolate(isolateId!);
 

--- a/lib/src/mixins/connection_support.dart
+++ b/lib/src/mixins/connection_support.dart
@@ -114,7 +114,9 @@ base mixin ConnectionSupport
                   '[mcp:connect] Resolved workspace root from client: $workspaceRoot');
             }
           }
-        } catch (_) {}
+        } catch (e) {
+          stderr.writeln('[mcp:connect] Error fetching client roots: $e');
+        }
       }
 
       if (workspaceRoot != null) {
@@ -206,7 +208,9 @@ base mixin ConnectionSupport
         await Future<void>.delayed(const Duration(milliseconds: 100));
         stderr.writeln(
             '[mcp:connect] Service stream seeded: ${registeredMethodsForService.keys.toList()}');
-      } catch (_) {}
+      } catch (e) {
+        stderr.writeln('[mcp:connect] Error seeding service stream: $e');
+      }
 
       // Clear existing I/O subscriptions and start buffering streams
       startLogging();
@@ -218,7 +222,10 @@ base mixin ConnectionSupport
           isolateId: isolateId,
           args: {'enabled': 'true'},
         );
-      } catch (_) {}
+      } catch (e) {
+        stderr
+            .writeln('[mcp:connect] Error enabling HTTP timeline logging: $e');
+      }
 
       final selectedIsolateName = vm.isolates!
           .firstWhere((i) => i.id == isolateId,
@@ -265,7 +272,9 @@ base mixin ConnectionSupport
 
     try {
       await vmService!.dispose();
-    } catch (_) {}
+    } catch (e) {
+      stderr.writeln('[mcp:connect] Error disposing VM Service: $e');
+    }
     vmService = null;
     vmServiceUri = null;
     isolateId = null;
@@ -288,7 +297,9 @@ base mixin ConnectionSupport
         isolateId: isolateId,
       );
       fpsVal = (fpsResponse.json?['fps'] as num?)?.toDouble() ?? 60.0;
-    } catch (_) {}
+    } catch (e) {
+      stderr.writeln('[mcp:connect] Error getting display refresh rate: $e');
+    }
 
     final extensionRPCs = isolate.extensionRPCs ?? [];
     final flutterExtensions =

--- a/lib/src/mixins/connection_support.dart
+++ b/lib/src/mixins/connection_support.dart
@@ -162,8 +162,11 @@ base mixin ConnectionSupport
       vmServiceUri = uriToConnect;
       final wsUri = normalizeToWsUri(uriToConnect);
       stderr.writeln('[mcp] Connecting to VM Service: $wsUri');
-
-      vmService = await vmServiceConnectUri(wsUri);
+      vmService = await vmServiceConnectUri(wsUri).timeout(
+        const Duration(seconds: 10),
+        onTimeout: () => throw TimeoutException(
+            'Timed out connecting to VM Service at $wsUri'),
+      );
 
       final vm = await vmService!.getVM();
       if (vm.isolates == null || vm.isolates!.isEmpty) {

--- a/lib/src/mixins/console_logging_support.dart
+++ b/lib/src/mixins/console_logging_support.dart
@@ -111,10 +111,14 @@ base mixin ConsoleLoggingSupport
           try {
             final decoded = utf8.decode(base64.decode(bytes));
             addToLogBuffer(logPrefix, decoded);
-          } catch (_) {}
+          } catch (e) {
+            stderr.writeln('[mcp:logging] Error decoding byte stream: $e');
+          }
         }
       });
-    } catch (_) {
+    } catch (e) {
+      stderr.writeln(
+          '[mcp:logging] Error listening to byte stream $streamId: $e');
       return null;
     }
   }

--- a/lib/src/mixins/debugger_support.dart
+++ b/lib/src/mixins/debugger_support.dart
@@ -7,8 +7,7 @@ import 'vm_connection_support.dart';
 base mixin DebuggerSupport on MCPServer, ToolsSupport, VmConnectionSupport {
   void registerDebuggerTools() {
     final formatSchema = StringSchema(
-      description:
-          'Response format: markdown or json (default: markdown).',
+      description: 'Response format: markdown or json (default: markdown).',
     );
 
     registerTool(
@@ -155,7 +154,9 @@ base mixin DebuggerSupport on MCPServer, ToolsSupport, VmConnectionSupport {
     try {
       await vmService!
           .setIsolatePauseMode(isolateId!, exceptionPauseMode: mode);
-    } catch (_) {
+    } catch (e) {
+      stderr.writeln(
+          '[mcp:debugger] setIsolatePauseMode failed: $e. Trying deprecated fallback.');
       // Fallback for older VM Service versions
       // ignore: deprecated_member_use
       await vmService!.setExceptionPauseMode(isolateId!, mode);

--- a/lib/src/mixins/deeplink_validation_support.dart
+++ b/lib/src/mixins/deeplink_validation_support.dart
@@ -8,8 +8,7 @@ base mixin DeeplinkValidationSupport
     on MCPServer, ToolsSupport, VmConnectionSupport {
   void registerDeeplinkTools() {
     final formatSchema = StringSchema(
-      description:
-          'Response format: markdown or json (default: markdown).',
+      description: 'Response format: markdown or json (default: markdown).',
     );
 
     registerTool(

--- a/lib/src/mixins/dtd_support.dart
+++ b/lib/src/mixins/dtd_support.dart
@@ -11,8 +11,7 @@ base mixin DtdSupport on MCPServer, ToolsSupport, VmConnectionSupport {
 
   void registerDtdTools() {
     final formatSchema = StringSchema(
-      description:
-          'Response format: markdown or json (default: markdown).',
+      description: 'Response format: markdown or json (default: markdown).',
     );
 
     registerTool(

--- a/lib/src/mixins/memory_debugging_support.dart
+++ b/lib/src/mixins/memory_debugging_support.dart
@@ -10,8 +10,7 @@ base mixin MemoryDebuggingSupport
 
   void registerMemoryTools() {
     final formatSchema = StringSchema(
-      description:
-          'Response format: markdown or json (default: markdown).',
+      description: 'Response format: markdown or json (default: markdown).',
     );
 
     registerTool(
@@ -175,11 +174,16 @@ base mixin MemoryDebuggingSupport
 
     for (final instanceRef in instances) {
       final instanceId = instanceRef.id!;
-      final evalResult =
-          await vmService!.evaluate(isolateId!, instanceId, 'this.mounted');
-
-      final isMounted =
-          evalResult is InstanceRef && evalResult.valueAsString == 'true';
+      bool isMounted = true;
+      try {
+        final evalResult =
+            await vmService!.evaluate(isolateId!, instanceId, 'this.mounted');
+        isMounted =
+            evalResult is InstanceRef && evalResult.valueAsString == 'true';
+      } catch (_) {
+        // Class doesn't have a mounted property, skip it
+        continue;
+      }
       if (!isMounted) {
         final retainingPath =
             await vmService!.getRetainingPath(isolateId!, instanceId, 15);

--- a/lib/src/mixins/network_capture_support.dart
+++ b/lib/src/mixins/network_capture_support.dart
@@ -15,8 +15,7 @@ base mixin NetworkCaptureSupport
 
   void registerNetworkTools() {
     final formatSchema = StringSchema(
-      description:
-          'Response format: markdown or json (default: markdown).',
+      description: 'Response format: markdown or json (default: markdown).',
     );
 
     registerTool(
@@ -195,7 +194,9 @@ base mixin NetworkCaptureSupport
 
     try {
       await vmService!.streamListen(EventStreams.kExtension);
-    } catch (_) {}
+    } catch (e) {
+      stderr.writeln('[mcp:network] Error subscribing to extension stream: $e');
+    }
 
     try {
       await vmService!.callServiceExtension(
@@ -203,7 +204,9 @@ base mixin NetworkCaptureSupport
         isolateId: isolateId!,
         args: {'enabled': 'true'},
       );
-    } catch (_) {}
+    } catch (e) {
+      stderr.writeln('[mcp:network] Error enabling HTTP timeline logging: $e');
+    }
 
     networkExtensionSub = vmService!.onExtensionEvent.listen((Event event) {
       final kind = event.extensionKind;
@@ -280,7 +283,9 @@ base mixin NetworkCaptureSupport
         isolateId: isolateId!,
         args: {'enabled': 'false'},
       );
-    } catch (_) {}
+    } catch (e) {
+      stderr.writeln('[mcp:network] Error disabling HTTP timeline logging: $e');
+    }
 
     final durationMs =
         DateTime.now().millisecondsSinceEpoch - networkCaptureStartTime!;

--- a/lib/src/mixins/performance_profiling_support.dart
+++ b/lib/src/mixins/performance_profiling_support.dart
@@ -13,8 +13,7 @@ base mixin PerformanceProfilingSupport
 
   void registerPerformanceTools() {
     final formatSchema = StringSchema(
-      description:
-          'Response format: markdown or json (default: markdown).',
+      description: 'Response format: markdown or json (default: markdown).',
     );
 
     registerTool(
@@ -388,7 +387,9 @@ base mixin PerformanceProfilingSupport
         isolateId: isolateId,
       );
       fpsVal = (fpsResponse.json?['fps'] as num?)?.toDouble() ?? 60.0;
-    } catch (_) {}
+    } catch (e) {
+      stderr.writeln('[mcp:profile] Error getting display refresh rate: $e');
+    }
 
     isProfiling = true;
     profilingStartTime = DateTime.now().millisecondsSinceEpoch;

--- a/lib/src/mixins/screenshot_support.dart
+++ b/lib/src/mixins/screenshot_support.dart
@@ -9,8 +9,7 @@ import 'vm_connection_support.dart';
 base mixin ScreenshotSupport on MCPServer, ToolsSupport, VmConnectionSupport {
   void registerScreenshotTools() {
     final formatSchema = StringSchema(
-      description:
-          'Response format: markdown or json (default: markdown).',
+      description: 'Response format: markdown or json (default: markdown).',
     );
 
     registerTool(
@@ -347,7 +346,10 @@ base mixin ScreenshotSupport on MCPServer, ToolsSupport, VmConnectionSupport {
             effectiveDeviceId = await _detectDeviceForOs(os);
           }
         }
-      } catch (_) {}
+      } catch (e) {
+        stderr.writeln(
+            '[mcp:screenshot] Error detecting VM OS or auto-detecting device: $e');
+      }
 
       final flutterRoot = Platform.environment['FLUTTER_ROOT'];
       final executable = flutterRoot != null
@@ -439,7 +441,9 @@ base mixin ScreenshotSupport on MCPServer, ToolsSupport, VmConnectionSupport {
           return emulator['id'] as String?;
         }
       }
-    } catch (_) {}
+    } catch (e) {
+      stderr.writeln('[mcp:screenshot] Error listing/matching devices: $e');
+    }
     return null;
   }
 }

--- a/lib/src/mixins/vm_connection_support.dart
+++ b/lib/src/mixins/vm_connection_support.dart
@@ -45,7 +45,7 @@ base mixin VmConnectionSupport on MCPServer, ToolsSupport {
     );
   }
 
-    Future<CallToolResult> Function(CallToolRequest) wrapToolCall(
+  Future<CallToolResult> Function(CallToolRequest) wrapToolCall(
     String toolName,
     FutureOr<CallToolResult> Function(CallToolRequest) handler, {
     bool requiresConnection = true,
@@ -89,6 +89,7 @@ base mixin VmConnectionSupport on MCPServer, ToolsSupport {
       }
     };
   }
+
   bool _isCollectedError(Object e) {
     final str = e.toString();
     return str.contains('Collected') ||

--- a/lib/src/mixins/vm_connection_support.dart
+++ b/lib/src/mixins/vm_connection_support.dart
@@ -45,7 +45,7 @@ base mixin VmConnectionSupport on MCPServer, ToolsSupport {
     );
   }
 
-  Future<CallToolResult> Function(CallToolRequest) wrapToolCall(
+    Future<CallToolResult> Function(CallToolRequest) wrapToolCall(
     String toolName,
     FutureOr<CallToolResult> Function(CallToolRequest) handler, {
     bool requiresConnection = true,
@@ -89,7 +89,6 @@ base mixin VmConnectionSupport on MCPServer, ToolsSupport {
       }
     };
   }
-
   bool _isCollectedError(Object e) {
     final str = e.toString();
     return str.contains('Collected') ||
@@ -151,9 +150,15 @@ base mixin VmConnectionSupport on MCPServer, ToolsSupport {
 
   bool isDtdUri(String uri) {
     final cleaned = uri.trim().toLowerCase();
-    return !cleaned.endsWith('/ws') &&
-        !cleaned.endsWith('/ws/') &&
-        !cleaned.contains('/ws?');
+    if (cleaned.endsWith('/ws') ||
+        cleaned.endsWith('/ws/') ||
+        cleaned.contains('/ws?')) {
+      return false;
+    }
+    if (cleaned.contains('auth_token=')) {
+      return false;
+    }
+    return true;
   }
 
   String normalizeToWsUri(String uri) {

--- a/lib/src/mixins/widget_inspection_support.dart
+++ b/lib/src/mixins/widget_inspection_support.dart
@@ -17,8 +17,7 @@ base mixin WidgetInspectionSupport
 
   void registerWidgetTools() {
     final formatSchema = StringSchema(
-      description:
-          'Response format: markdown or json (default: markdown).',
+      description: 'Response format: markdown or json (default: markdown).',
     );
 
     registerTool(
@@ -303,8 +302,7 @@ base mixin WidgetInspectionSupport
 
   Future<CallToolResult> _handleInspectLayoutConstraints(
       CallToolRequest req) async {
-    final widgetId =
-        (req.arguments!['widget_id'] ?? req.arguments!['widgetId']) as String;
+    final widgetId = req.arguments!['widgetId'] as String;
     stderr.writeln('[mcp:inspect_layout] Inspecting widget: $widgetId');
 
     final response = await vmService!.callServiceExtension(

--- a/lib/src/mixins/widget_inspection_support.dart
+++ b/lib/src/mixins/widget_inspection_support.dart
@@ -488,7 +488,9 @@ base mixin WidgetInspectionSupport
       } else {
         currentDirs = res.toString();
       }
-    } catch (_) {}
+    } catch (e) {
+      stderr.writeln('[mcp:widget] Error fetching pubRootDirectories: $e');
+    }
 
     return CallToolResult(
       content: [
@@ -675,7 +677,10 @@ base mixin WidgetInspectionSupport
             node['children'] = result;
             childrenList = result;
           }
-        } catch (_) {}
+        } catch (e) {
+          stderr.writeln(
+              '[mcp:widget] Error resolving child details subtree: $e');
+        }
       }
     }
 
@@ -934,7 +939,9 @@ base mixin WidgetInspectionSupport
       } else if (rawLocationResult is Map) {
         _parseLocationsMap(rawLocationResult, rebuildIdToName, rebuildIdToFile);
       }
-    } catch (_) {}
+    } catch (e) {
+      stderr.writeln('[mcp:widget] Error fetching widget location ID map: $e');
+    }
 
     final widgets = <Map<String, dynamic>>[];
     var totalRebuilds = 0;
@@ -1129,10 +1136,15 @@ base mixin WidgetInspectionSupport
       } else if (rawLocationResult is Map) {
         _parseLocationsMap(rawLocationResult, idToName, idToFile);
       }
-    } catch (_) {}
+    } catch (e) {
+      stderr.writeln(
+          '[mcp:widget] Error enabling rebuild tracking locations: $e');
+    }
     try {
       await vmService!.streamListen(EventStreams.kExtension);
-    } catch (_) {}
+    } catch (e) {
+      stderr.writeln('[mcp:widget] Error listening to extension stream: $e');
+    }
   }
 }
 

--- a/lib/src/path_resolver.dart
+++ b/lib/src/path_resolver.dart
@@ -61,9 +61,20 @@ class PathResolver {
               directory.listSync(recursive: true, followLinks: false);
           for (final entity in entities) {
             if (entity is File) {
-              final name = p.basename(entity.path);
+              final filePath = entity.path;
+              final separator = p.separator;
+              if (filePath.contains('$separator.git$separator') ||
+                  filePath.contains('$separator.dart_tool$separator') ||
+                  filePath.contains('$separator.github$separator') ||
+                  filePath.contains('$separator.idea$separator') ||
+                  filePath.contains('$separator.vscode$separator') ||
+                  filePath.contains('${separator}build$separator') ||
+                  filePath.contains('${separator}node_modules$separator')) {
+                continue;
+              }
+              final name = p.basename(filePath);
               _allWorkspaceFiles!
-                  .putIfAbsent(name, () => p.canonicalize(entity.path));
+                  .putIfAbsent(name, () => p.canonicalize(filePath));
             }
           }
         }

--- a/lib/src/path_resolver.dart
+++ b/lib/src/path_resolver.dart
@@ -67,7 +67,9 @@ class PathResolver {
             }
           }
         }
-      } catch (_) {}
+      } catch (e) {
+        stderr.writeln('[mcp:path_resolver] Error walking workspace: $e');
+      }
     }
 
     final matchedPath = _allWorkspaceFiles![fileName];

--- a/lib/src/port_discovery.dart
+++ b/lib/src/port_discovery.dart
@@ -38,7 +38,8 @@ Future<List<DiscoveredApp>> discoverActiveApps() async {
       dynamic decoded;
       try {
         decoded = jsonDecode(rawJson);
-      } catch (_) {
+      } catch (e) {
+        stderr.writeln('[discovery] Failed to decode PowerShell JSON: $e');
         return apps;
       }
 


### PR DESCRIPTION
This pull request adds connection safety checks, timeout limits, and error logging to the MCP server. These changes prevent server crashes and make errors easier to debug.

### Changes by File

#### connection_support.dart
* Added null checks to `get_app_info` to prevent crashes when the VM service or active isolate is missing.
* Added a 10-second timeout limit to VM Service connection attempts to prevent hanging.
* Updated the connection success message to report the correct active isolate name instead of always using the first isolate.
* Logged connection and autodiscovery errors to stderr.

#### memory_debugging_support.dart
* Wrapped `mounted` checks in try-catch blocks. This prevents crashes when inspecting classes that do not inherit from `State`.

#### widget_inspection_support.dart
* Removed unused `widget_id` fallback lookup in the layout inspection handler.
* Logged widget inspection and stream subscription errors to stderr.

#### vm_connection_support.dart
* Improved DTD URI checks. The parser now correctly flags endpoints containing `auth_token=` as VM Service URIs rather than DTD endpoints.

#### path_resolver.dart
* Filtered out build, system, and dependency directories (`.git`, `build`, `node_modules`, `.dart_tool`) from fallback workspace walks. This prevents slow filesystem queries.
* Logged file search errors to stderr.

#### Logging & Stderr Outputs
* Replaced empty catch blocks with stderr logging across all remaining tool mixins (console logging, screenshots, performance profiling, network capture, bundle analysis, and port discovery).