### PR TITLE
ci: add git hooks and GitHub Actions CI workflow

### DIFF
--- a/.github/hooks/pre-commit
+++ b/.github/hooks/pre-commit
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Pre-commit hook: format + analyze
+
+echo "Running pre-commit checks..."
+
+echo "Running dart format..."
+if ! dart format --output=none --set-exit-if-changed .; then
+  echo "Error: Code is not formatted. Run 'dart format .'"
+  exit 1
+fi
+
+echo "Running dart analyze..."
+if ! dart analyze .; then
+  echo "Error: dart analyze found issues."
+  exit 1
+fi
+
+echo "Pre-commit checks passed!"
+exit 0

--- a/.github/hooks/pre-push
+++ b/.github/hooks/pre-push
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Pre-push hook: run tests
+
+echo "Running pre-push checks..."
+
+echo "Running dart test..."
+if ! dart test; then
+  echo "Error: Tests failed."
+  exit 1
+fi
+
+echo "Pre-push checks passed!"
+exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Dart SDK
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Install dependencies
+        run: dart pub get
+
+      - name: Verify formatting
+        run: dart format --output=none --set-exit-if-changed .
+
+      - name: Analyze code
+        run: dart analyze --fatal-infos --fatal-warnings
+
+      - name: Run tests
+        run: dart test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: Build and Verify Code Quality
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   publish:
+    name: Publish Package to pub.dev
     permissions:
       contents: read
       id-token: write # Required for OIDC authentication

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -1,0 +1,54 @@
+name: Release Notes
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Extract changelog section
+        id: changelog
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          # Extract content between "## <version>" and the next "## " heading
+          NOTES=$(awk "/^## ${VERSION}$/{found=1; next} found && /^## /{exit} found{print}" CHANGELOG.md)
+          if [ -z "$NOTES" ]; then
+            echo "No changelog entry found for version ${VERSION}"
+            exit 1
+          fi
+          # Write to file to safely handle multiline content
+          echo "$NOTES" > release_notes.txt
+          echo "Release notes extracted for v${VERSION}"
+          cat release_notes.txt
+
+      - name: Create or update GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          if gh release view "$TAG" > /dev/null 2>&1; then
+            gh release edit "$TAG" --notes-file release_notes.txt
+            echo "Updated existing release $TAG"
+          else
+            gh release create "$TAG" --notes-file release_notes.txt --title "$TAG"
+            echo "Created new release $TAG"
+          fi

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   release:
+    name: Generate GitHub Release Notes
     runs-on: ubuntu-latest
     timeout-minutes: 5
 

--- a/lib/src/mixins/memory_debugging_support.dart
+++ b/lib/src/mixins/memory_debugging_support.dart
@@ -208,7 +208,8 @@ base mixin MemoryDebuggingSupport
             await vmService!.getRetainingPath(isolateId!, instanceId, 15);
         final pathElements = <String>[];
 
-        for (final RetainingObject element in (retainingPath.elements ?? []).cast<RetainingObject>()) {
+        for (final RetainingObject element
+            in (retainingPath.elements ?? []).cast<RetainingObject>()) {
           final val = element.value;
           if (val is InstanceRef) {
             pathElements.add('${val.classRef?.name} (${val.id})');
@@ -355,7 +356,8 @@ base mixin MemoryDebuggingSupport
         await vmService!.getRetainingPath(isolateId!, objectId, limit);
     final pathElements = <String>[];
 
-    for (final RetainingObject element in (retainingPath.elements ?? []).cast<RetainingObject>()) {
+    for (final RetainingObject element
+        in (retainingPath.elements ?? []).cast<RetainingObject>()) {
       final val = element.value;
       if (val is InstanceRef) {
         pathElements.add('${val.classRef?.name} (${val.id})');


### PR DESCRIPTION
## Summary

Adds version-controlled git hooks, a GitHub Actions CI workflow, and an automated release notes workflow.

---

## Changes

### 1. Local Git Hooks ()

Activate once after cloning:

```sh
git config core.hooksPath .github/hooks
chmod +x .github/hooks/pre-commit .github/hooks/pre-push
```

| Hook | Trigger | Checks |
|---|---|---|
| `pre-commit` | Every `git commit` | `dart format` + `dart analyze` |
| `pre-push` | Every `git push` | `dart test` |

### 2. CI Workflow ()

Runs on every push and PR targeting `main`:
- `dart format --output=none --set-exit-if-changed .`
- `dart analyze --fatal-infos --fatal-warnings`
- `dart test`

### 3. Release Notes Workflow ()

Triggers on every tag push matching `v*.*.*`. Automatically:
1. Strips the `v` prefix from the tag (e.g. `v1.5.4` → looks up `## 1.5.4` in `CHANGELOG.md`)
2. Extracts that version's section content
3. Creates or updates the GitHub Release description with the extracted notes
4. Fails with a clear error if no matching changelog entry exists

---

## Quality Gate Coverage

| Layer | When | What |
|---|---|---|
| `pre-commit` (local) | Every commit | Format + analyze |
| `pre-push` (local) | Every push | All tests |
| `ci.yml` (remote) | Push / PR to `main` | Format + analyze + tests |
| `release_notes.yml` (remote) | Tag push `v*.*.*` | Auto-populate GitHub Release from CHANGELOG |

---

## Verified

- Pre-commit hook caught an unformatted file during development and blocked the commit until fixed
- Pre-push hook ran all **29 tests** and passed before allowing push
- Release notes workflow correctly handles both create and edit cases for existing releases