### PR TITLE
feat: exclude built-in and SDK widgets from rebuild tracking report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.6.1
+
+### Added
+- Added `exclude_flutter_widgets` option (default: `true`) to `rebuild_tracking` to filter out built-in framework and dependency widgets.
+
 ## 1.6.0
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ To keep payloads light, these settings are supported:
 - **Layout Controls**:
   - `maxDepth` in `widget` (action: `get_tree`): Sets widget tree depth (default: `8`).
   - `projectOnly` in `widget` (action: `get_tree`): Filters out non-user-project widgets (default: `true`).
+  - `exclude_flutter_widgets` in `rebuild_tracking` (action: `stop` / `get_counts`): Excludes built-in Flutter/SDK and dependency widgets from the rebuild list (default: `true`).
 
 - **Platform Settings**:
   - `platform` in `diagnose_project` (action: `deep_links`): Platform target (e.g. `android` or `ios`, required).

--- a/lib/flutter_agent_lens.dart
+++ b/lib/flutter_agent_lens.dart
@@ -45,7 +45,7 @@ final class FlutterAgentLensServer extends MCPServer
           channel,
           implementation: Implementation(
             name: 'flutter_agent_lens',
-            version: '1.6.0',
+            version: '1.6.1',
           ),
           instructions: 'A tool server to interact with running Flutter apps. '
               'Connect using the connect tool, or discover running apps with discover_apps.',

--- a/lib/src/mixins/connection_support.dart
+++ b/lib/src/mixins/connection_support.dart
@@ -22,6 +22,8 @@ base mixin ConnectionSupport
         VmConnectionSupport,
         ConsoleLoggingSupport,
         RootsTrackingSupport {
+  static const _validSchemes = {'ws', 'wss', 'http', 'https'};
+
   /// The active connection to the Dart Tooling Daemon.
   DartToolingDaemon? dtdClient;
 
@@ -185,8 +187,7 @@ base mixin ConnectionSupport
           'Required parameter "uri" or "vmServiceUri" is missing.'),
     };
     final parsed = Uri.tryParse(rawUri);
-    if (parsed == null ||
-        !{'ws', 'wss', 'http', 'https'}.contains(parsed.scheme)) {
+    if (parsed == null || !_validSchemes.contains(parsed.scheme)) {
       return CallToolResult(
         content: [
           TextContent(
@@ -368,7 +369,9 @@ base mixin ConnectionSupport
   Future<void> _resolveWorkspaceRoot(CallToolRequest req) async {
     workspaceRoot = req.arg<String>('workspace_root');
 
-    if (workspaceRoot == null || workspaceRoot!.isEmpty) {
+    if (workspaceRoot case final root? when root.isNotEmpty) {
+      // workspaceRoot is already resolved and not empty
+    } else {
       try {
         final clientRoots = await roots;
         if (clientRoots.isNotEmpty) {
@@ -385,8 +388,9 @@ base mixin ConnectionSupport
       }
     }
 
-    if (workspaceRoot != null) {
-      pathResolver = PathResolver(workspaceRoot!);
+    if (workspaceRoot case final root? when root.isNotEmpty) {
+      pathResolver = PathResolver(root);
+      await loadWorkspacePackages();
     }
   }
 
@@ -461,9 +465,10 @@ base mixin ConnectionSupport
         content: [TextContent(text: report.toString().trim())],
       );
     } catch (e) {
-      if (dtdClient != null) {
+      final client = dtdClient;
+      if (client != null) {
         try {
-          await dtdClient!.close();
+          await client.close();
         } catch (_) {}
         dtdClient = null;
         dtdUri = null;
@@ -564,6 +569,12 @@ base mixin ConnectionSupport
     vmService = null;
     vmServiceUri = null;
     isolateId = null;
+    workspaceRoot = null;
+    pathResolver = null;
+    cachedLibraryId = null;
+    cachedPackageName = null;
+    packageResolver = null;
+    isBuiltInWidgetCache.clear();
     return CallToolResult(
       content: [TextContent(text: 'Disconnected from Flutter app.')],
     );

--- a/lib/src/mixins/rebuild_tracking_support.dart
+++ b/lib/src/mixins/rebuild_tracking_support.dart
@@ -48,6 +48,10 @@ base mixin RebuildTrackingSupport
               description:
                   'Number of top rebuilding widgets to list (default: 30).',
             ),
+            'exclude_flutter_widgets': BooleanSchema(
+              description:
+                  'Whether to exclude built-in Flutter/SDK widgets (default: true).',
+            ),
           },
           required: ['action'],
         ),
@@ -70,9 +74,49 @@ base mixin RebuildTrackingSupport
     rebuildIdToFile.clear();
   }
 
+  Future<List<Map<String, dynamic>>> _resolveAndFilterWidgets({
+    required Map<String, int> counts,
+    required Map<String, String> idToName,
+    required Map<String, String> idToFile,
+    required bool excludeBuiltIn,
+    required String? projectName,
+  }) async {
+    final widgets = <Map<String, dynamic>>[];
+    final resolver = pathResolver;
+
+    for (final entry in counts.entries) {
+      final locId = entry.key;
+      final count = entry.value;
+      final name = idToName[locId] ?? 'Widget#$locId';
+      final rawFile = idToFile[locId] ?? 'unknown';
+
+      // Apply filter on raw file path BEFORE resolution
+      if (excludeBuiltIn &&
+          isBuiltInWidget(rawFile, projectName: projectName)) {
+        continue;
+      }
+
+      final resolvedPath = resolver != null
+          ? await resolver.resolveToAbsolutePath(rawFile)
+          : rawFile;
+      widgets.add({
+        'widget': name,
+        'count': count,
+        'location': resolvedPath,
+        'id': locId,
+      });
+    }
+
+    widgets.sort((a, b) => (b['count'] as int).compareTo(a['count'] as int));
+    return widgets;
+  }
+
   Future<CallToolResult> _handleWidgetRebuildCounts(CallToolRequest req) async {
     final duration = (req.arg<num>('duration_seconds'))?.toInt() ?? 3;
     final topN = (req.arg<num>('topN'))?.toInt() ?? 30;
+    final excludeBuiltIn = req.arg<bool>('exclude_flutter_widgets') ?? true;
+    final projectName = excludeBuiltIn ? await getProjectPackageName() : null;
+
     stderr.writeln(
         '[mcp:widget_rebuild_counts] Starting rebuild tracking, duration=${duration}s');
 
@@ -119,7 +163,7 @@ base mixin RebuildTrackingSupport
           isolateId: isolateId,
           args: {'enabled': 'false'},
         );
-      } catch (e) {
+      } on Exception catch (e) {
         stderr.writeln(
             '[mcp:widget_rebuild_counts] Error disabling trackRebuildDirtyWidgets: $e');
       }
@@ -146,26 +190,19 @@ base mixin RebuildTrackingSupport
     stderr.writeln(
         '[mcp:widget_rebuild_counts] Location map: ${idToName.length} named, ${idToFile.length} with files');
 
-    final widgets = <Map<String, dynamic>>[];
-    for (final entry in widgetCounts.entries) {
-      final locId = entry.key;
-      final count = entry.value;
-      final name = idToName[locId] ?? 'Widget#$locId';
-      final rawFile = idToFile[locId] ?? 'unknown';
-      final resolvedPath = pathResolver != null
-          ? await pathResolver!.resolveToAbsolutePath(rawFile)
-          : rawFile;
-      widgets.add({
-        'widget': name,
-        'count': count,
-        'location': resolvedPath,
-        'id': locId,
-      });
-    }
-
-    widgets.sort((a, b) => (b['count'] as int).compareTo(a['count'] as int));
+    final widgets = await _resolveAndFilterWidgets(
+      counts: widgetCounts,
+      idToName: idToName,
+      idToFile: idToFile,
+      excludeBuiltIn: excludeBuiltIn,
+      projectName: projectName,
+    );
 
     final mdBuffer = StringBuffer('Top Rebuilding Widgets\n\n');
+    if (excludeBuiltIn) {
+      mdBuffer.writeln(
+          '_Note: Built-in Flutter/SDK widgets excluded. Pass `exclude_flutter_widgets: false` to include them._\n');
+    }
     if (widgets.isEmpty) {
       mdBuffer.writeln(
           'No rebuilds captured. Make sure you interacted with the app while tracking.');
@@ -182,6 +219,8 @@ base mixin RebuildTrackingSupport
       title: 'Widget Rebuilt Counts Analysis',
       markdownBody: mdBuffer.toString(),
       structuredData: {
+        'total_recorded_widgets': widgetCounts.length,
+        'filtered_count': widgets.length,
         'widgets': widgets.take(topN).toList(),
       },
     );
@@ -267,6 +306,8 @@ base mixin RebuildTrackingSupport
     }
 
     final topN = (req.arg<num>('topN'))?.toInt() ?? 30;
+    final excludeBuiltIn = req.arg<bool>('exclude_flutter_widgets') ?? true;
+    final projectName = excludeBuiltIn ? await getProjectPackageName() : null;
 
     stderr.writeln(
         '[mcp:widget_rebuild_counts] Stopping rebuild tracking session...');
@@ -280,7 +321,7 @@ base mixin RebuildTrackingSupport
         isolateId: isolateId,
         args: {'enabled': 'false'},
       );
-    } catch (e) {
+    } on Exception catch (e) {
       stderr.writeln(
           '[mcp:widget_rebuild_counts] Error disabling trackRebuildDirtyWidgets: $e');
     }
@@ -302,31 +343,22 @@ base mixin RebuildTrackingSupport
       } else if (rawLocationResult is Map) {
         _parseLocationsMap(rawLocationResult, rebuildIdToName, rebuildIdToFile);
       }
-    } catch (e) {
+    } on Exception catch (e) {
       stderr.writeln('[mcp:widget] Error fetching widget location ID map: $e');
     }
 
-    final widgets = <Map<String, dynamic>>[];
+    final widgets = await _resolveAndFilterWidgets(
+      counts: rebuildCounts,
+      idToName: rebuildIdToName,
+      idToFile: rebuildIdToFile,
+      excludeBuiltIn: excludeBuiltIn,
+      projectName: projectName,
+    );
+
     var totalRebuilds = 0;
-
-    for (final entry in rebuildCounts.entries) {
-      final locId = entry.key;
-      final count = entry.value;
+    for (final count in rebuildCounts.values) {
       totalRebuilds += count;
-      final name = rebuildIdToName[locId] ?? 'Widget#$locId';
-      final rawFile = rebuildIdToFile[locId] ?? 'unknown';
-      final resolvedPath = pathResolver != null
-          ? await pathResolver!.resolveToAbsolutePath(rawFile)
-          : rawFile;
-      widgets.add({
-        'widget': name,
-        'count': count,
-        'location': resolvedPath,
-        'id': locId,
-      });
     }
-
-    widgets.sort((a, b) => (b['count'] as int).compareTo(a['count'] as int));
 
     final output = [
       'WIDGET REBUILD REPORT',
@@ -334,9 +366,14 @@ base mixin RebuildTrackingSupport
       'SUMMARY',
       'Tracked for ${durationSec}s',
       'Total rebuilds: $totalRebuilds',
-      'Unique widgets rebuilt: ${widgets.length}',
-      '',
+      'Unique widgets rebuilt: ${rebuildCounts.length}',
     ];
+
+    if (excludeBuiltIn) {
+      output.add(
+          'Filtered widgets: ${widgets.length} (excluding built-in Flutter/SDK widgets)');
+    }
+    output.add('');
 
     if (widgets.isEmpty) {
       output.add(
@@ -358,13 +395,12 @@ base mixin RebuildTrackingSupport
         final name = w['widget'] as String;
         final fileLoc = w['location'] as String;
         final shortFile = getShortFile(fileLoc);
-        final severity = count > 100
-            ? '[HIGH]'
-            : count > 30
-                ? '[MEDIUM]'
-                : count > 10
-                    ? '[LOW]'
-                    : '[OK]';
+        final severity = switch (count) {
+          > 100 => '[HIGH]',
+          > 30 => '[MEDIUM]',
+          > 10 => '[LOW]',
+          _ => '[OK]',
+        };
         output.add('$severity ${count}x | $name [$shortFile]');
       }
 
@@ -394,7 +430,8 @@ base mixin RebuildTrackingSupport
       markdownBody: output.join('\n'),
       structuredData: {
         'duration_seconds': double.tryParse(durationSec) ?? 0.0,
-        'total_recorded_widgets': widgets.length,
+        'total_recorded_widgets': rebuildCounts.length,
+        'filtered_count': widgets.length,
         'total_rebuilds': totalRebuilds,
         'rebuilds': widgets.take(topN).toList(),
       },
@@ -439,7 +476,7 @@ base mixin RebuildTrackingSupport
       if (e.code != 103) {
         stderr.writeln('[mcp:widget] Error listening to extension stream: $e');
       }
-    } catch (e) {
+    } on Exception catch (e) {
       stderr.writeln('[mcp:widget] Error listening to extension stream: $e');
     }
   }

--- a/lib/src/mixins/vm_connection_support.dart
+++ b/lib/src/mixins/vm_connection_support.dart
@@ -5,11 +5,16 @@ import 'dart:io';
 import 'package:dart_mcp/server.dart';
 import 'package:flutter_agent_lens/src/enums/mcp_tool.dart';
 import 'package:flutter_agent_lens/src/path_resolver.dart';
+import 'package:flutter_agent_lens/src/utils/workspace_package_resolver.dart';
+import 'package:path/path.dart' as p;
 import 'package:vm_service/vm_service.dart';
 
 /// Base support mixin providing VM connection management, isolate management,
 /// and common schema definitions for Flutter Agent Lens MCP tools.
 base mixin VmConnectionSupport on MCPServer, ToolsSupport {
+  static final _lineNumberSuffix = RegExp(r':(\d+)$');
+  static final _pubspecNamePattern = RegExp(r'(?:^|\n)name:\s*([A-Za-z0-9_]+)');
+
   /// The active connection to the Dart VM Service.
   VmService? vmService;
 
@@ -27,6 +32,15 @@ base mixin VmConnectionSupport on MCPServer, ToolsSupport {
 
   /// Cached main library ID of the target application.
   String? cachedLibraryId;
+
+  /// Cached project package name (e.g. 'my_app' from 'package:my_app/main.dart').
+  String? cachedPackageName;
+
+  /// Resolver for workspace packages.
+  WorkspacePackageResolver? packageResolver;
+
+  /// Cache for high-frequency isBuiltInWidget lookups.
+  final Map<String, bool> isBuiltInWidgetCache = {};
 
   /// Tracks dynamically registered service methods (e.g. 'hotRestart' -> 's0.hotRestart').
   final Map<String, String> registeredMethodsForService = {};
@@ -178,6 +192,9 @@ base mixin VmConnectionSupport on MCPServer, ToolsSupport {
           isolateId = isolates.first.id;
         }
         cachedLibraryId = null;
+        cachedPackageName = null;
+        packageResolver = null;
+        isBuiltInWidgetCache.clear();
         stderr.writeln(
             '[mcp] Dynamically refreshed active isolate ID: $isolateId');
         return true;
@@ -367,7 +384,50 @@ base mixin VmConnectionSupport on MCPServer, ToolsSupport {
     return firstId;
   }
 
-  /// Formats raw byte counts into human-readable strings (e.g. KB, MB, GB).
+  /// Get the project's package name.
+  /// Reads name from pubspec.yaml if workspaceRoot exists; falls back to isolate libraries.
+  Future<String?> getProjectPackageName() async {
+    if (cachedPackageName != null) return cachedPackageName;
+
+    // Read from pubspec.yaml
+    if (workspaceRoot case final root? when root.isNotEmpty) {
+      try {
+        final file = File(p.join(root, 'pubspec.yaml'));
+        if (file.existsSync()) {
+          final content = await file.readAsString();
+          final match = _pubspecNamePattern.firstMatch(content);
+          if (match != null) {
+            return cachedPackageName = match.group(1);
+          }
+        }
+      } catch (_) {}
+    }
+
+    // Fallback: parse isolate libraries
+    final activeIsolateId = isolateId;
+    if (vmService == null || activeIsolateId == null) return null;
+    try {
+      final isolate = await vmService!.getIsolate(activeIsolateId);
+      final libraries = isolate.libraries ?? [];
+      for (final lib in libraries) {
+        final uri = lib.uri ?? '';
+        if (uri.startsWith('package:') && uri.endsWith('main.dart')) {
+          return cachedPackageName =
+              uri.substring(8, uri.indexOf('/')); // 'package:'.length == 8
+        }
+      }
+      // Fallback: use first non-flutter package URI
+      for (final lib in libraries) {
+        final uri = lib.uri ?? '';
+        if (uri.startsWith('package:') && !uri.startsWith('package:flutter/')) {
+          return cachedPackageName = uri.substring(8, uri.indexOf('/'));
+        }
+      }
+    } catch (_) {}
+    return null;
+  }
+
+  /// Format byte counts to human readable strings.
   String formatBytes(int bytes) {
     if (bytes == 0) return '0 B';
     final sign = bytes < 0 ? '-' : '';
@@ -379,5 +439,122 @@ base mixin VmConnectionSupport on MCPServer, ToolsSupport {
       i++;
     }
     return '$sign${absVal.toStringAsFixed(2)} ${units[i]}';
+  }
+
+  /// Load local and external packages using WorkspacePackageResolver.
+  Future<void> loadWorkspacePackages() async {
+    if (workspaceRoot case final root? when root.isNotEmpty) {
+      packageResolver = WorkspacePackageResolver(root);
+      await packageResolver!.load();
+      isBuiltInWidgetCache.clear();
+    }
+  }
+
+  /// Checks if the path belongs to a built-in/SDK widget or external package.
+  bool isBuiltInWidget(String rawFilePath, {String? projectName}) {
+    final cleanPath = stripLineNumber(rawFilePath);
+    if (isBuiltInWidgetCache.containsKey(cleanPath)) {
+      return isBuiltInWidgetCache[cleanPath]!;
+    }
+    final result = _evaluateIsBuiltIn(cleanPath, projectName: projectName);
+    isBuiltInWidgetCache[cleanPath] = result;
+    return result;
+  }
+
+  bool _evaluateIsBuiltIn(String cleanPath, {String? projectName}) {
+    var path = cleanPath;
+
+    // Convert file URIs
+    if (path.startsWith('file:')) {
+      try {
+        path = Uri.parse(path).toFilePath();
+      } catch (_) {
+        if (path.startsWith('file:///')) {
+          path = path.substring(7);
+        } else if (path.startsWith('file://')) {
+          path = path.substring(7);
+        } else if (path.startsWith('file:')) {
+          path = path.substring(5);
+        }
+      }
+    }
+
+    // Scheme checks
+    if (path.startsWith('dart:') ||
+        path.startsWith('org-dartlang-sdk:') ||
+        path.startsWith('native')) {
+      return true;
+    }
+
+    // Package URIs
+    if (path.startsWith('package:')) {
+      final slashIdx = path.indexOf('/');
+      if (slashIdx != -1) {
+        final pkgName = path.substring(8, slashIdx);
+        final resolver = packageResolver;
+        if (resolver != null) {
+          if (resolver.localPackages.contains(pkgName)) return false;
+          if (resolver.externalPackages.contains(pkgName)) return true;
+        }
+      }
+
+      // Fallback
+      if (projectName case final name? when name.isNotEmpty) {
+        return !path.startsWith('package:$name/');
+      }
+      // Exclude core flutter packages
+      return path.startsWith('package:flutter/') ||
+          path.startsWith('package:flutter_test/');
+    }
+
+    // Make relative paths absolute using workspaceRoot
+    if (p.isRelative(path)) {
+      if (workspaceRoot case final root? when root.isNotEmpty) {
+        path = p.join(root, path);
+      }
+    }
+
+    // Boundary check against workspaceRoot
+    if (workspaceRoot case final root? when root.isNotEmpty) {
+      try {
+        final canonicalRoot = p.canonicalize(root);
+        final canonicalPath = p.canonicalize(path);
+        return !canonicalPath.startsWith(canonicalRoot);
+      } catch (_) {
+        // Treat as external if canonicalization fails
+        return true;
+      }
+    }
+
+    // Fallback if workspaceRoot is null
+    try {
+      final sdkPath =
+          p.canonicalize(p.dirname(p.dirname(Platform.resolvedExecutable)));
+      if (p.canonicalize(path).startsWith(sdkPath)) {
+        return true;
+      }
+    } catch (_) {}
+
+    final lowerPath = path.toLowerCase();
+    if (lowerPath.contains('pub-cache') ||
+        lowerPath.contains('pub_cache') ||
+        lowerPath.contains('.puro') ||
+        lowerPath.contains('.fvm') ||
+        lowerPath.contains('.mise') ||
+        lowerPath.contains('sky_engine') ||
+        lowerPath.contains('/packages/flutter/')) {
+      return true;
+    }
+
+    return false;
+  }
+
+  /// Strip ':lineNumber' suffix.
+  String stripLineNumber(String location) {
+    final match = _lineNumberSuffix.firstMatch(location);
+    if (match != null) {
+      return location.substring(0, match.start);
+    }
+    return location;
   }
 }

--- a/lib/src/utils/workspace_package_resolver.dart
+++ b/lib/src/utils/workspace_package_resolver.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+/// Parses and caches package configurations from .dart_tool/package_config.json.
+class WorkspacePackageResolver {
+  /// Creates a resolver for the given [workspaceRoot] directory.
+  WorkspacePackageResolver(this.workspaceRoot);
+
+  /// Absolute path to the workspace root directory.
+  final String workspaceRoot;
+  final Set<String> _localPackages = {};
+  final Set<String> _externalPackages = {};
+  DateTime? _lastModified;
+
+  /// Packages whose root directory resides inside [workspaceRoot].
+  Set<String> get localPackages => Set.unmodifiable(_localPackages);
+
+  /// Packages resolved to locations outside the workspace (pub-cache, SDK, etc.).
+  Set<String> get externalPackages => Set.unmodifiable(_externalPackages);
+
+  /// Adds a package name to the local packages set (primarily for testing).
+  void addLocalPackage(String name) => _localPackages.add(name);
+
+  /// Adds a package name to the external packages set (primarily for testing).
+  void addExternalPackage(String name) => _externalPackages.add(name);
+
+  /// Loads the package configuration from disk.
+  Future<void> load() async {
+    final configPath =
+        p.join(workspaceRoot, '.dart_tool', 'package_config.json');
+    final configFile = File(configPath);
+    if (!configFile.existsSync()) return;
+
+    try {
+      final stat = configFile.statSync();
+      if (_lastModified != null && !stat.modified.isAfter(_lastModified!)) {
+        return;
+      }
+      _lastModified = stat.modified;
+
+      final content = await configFile.readAsString();
+      final json = jsonDecode(content) as Map<String, dynamic>;
+      final packages = json['packages'] as List<dynamic>? ?? [];
+      final canonicalRoot = p.canonicalize(workspaceRoot);
+      final baseUri = Uri.file(p.join(workspaceRoot, '.dart_tool/'));
+
+      _localPackages.clear();
+      _externalPackages.clear();
+
+      for (final pkg in packages) {
+        if (pkg is! Map) continue;
+        final name = pkg['name'] as String?;
+        final rootUriStr = pkg['rootUri'] as String?;
+        if (name == null || rootUriStr == null) continue;
+
+        try {
+          final resolvedUri = baseUri.resolve(rootUriStr);
+          // toFilePath() throws UnsupportedError for non-file schemes.
+          final absPath = resolvedUri.toFilePath();
+          final canonicalPath = p.canonicalize(absPath);
+
+          if (canonicalPath.startsWith(canonicalRoot)) {
+            _localPackages.add(name);
+          } else {
+            _externalPackages.add(name);
+          }
+        } catch (_) {
+          // Skip package if resolution fails
+        }
+      }
+    } catch (_) {}
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_agent_lens
 description: Agent-first MCP server to debug, profile, and optimize running Flutter apps.
-version: 1.6.0
+version: 1.6.1
 homepage: https://github.com/dhruvanbhalara/flutter_agent_lens
 repository: https://github.com/dhruvanbhalara/flutter_agent_lens
 

--- a/test/unit/rebuild_tracking_test.dart
+++ b/test/unit/rebuild_tracking_test.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:dart_mcp/server.dart';
 import 'package:flutter_agent_lens/src/mixins/rebuild_tracking_support.dart';
 import 'package:flutter_agent_lens/src/mixins/vm_connection_support.dart';
+import 'package:flutter_agent_lens/src/utils/workspace_package_resolver.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
@@ -48,6 +50,13 @@ class FakeVmServiceForRebuilds extends vm_service.VmService {
         'ext.flutter.inspector.trackRebuildDirtyWidgets',
         'ext.flutter.inspector.widgetLocationIdMap',
       ],
+      libraries: [
+        vm_service.LibraryRef(
+          id: 'lib_1',
+          name: 'my_app',
+          uri: 'package:my_app/main.dart',
+        ),
+      ],
     );
   }
 
@@ -58,17 +67,45 @@ class FakeVmServiceForRebuilds extends vm_service.VmService {
     Map<String, dynamic>? args,
   }) async {
     if (method == 'ext.flutter.inspector.widgetLocationIdMap') {
-      return vm_service.Response.parse({
+      final parsed = vm_service.Response.parse({
         'result': {
           'package:my_app/main.dart': {
-            'ids': [1, 2, 3],
-            'lines': [10, 20, 30],
-            'names': ['AWidget', 'BWidget', 'CWidget']
+            'ids': [1, 2],
+            'lines': [10, 20],
+            'names': ['MyWidget', 'AppScreen']
+          },
+          'package:flutter/src/widgets/container.dart': {
+            'ids': [3, 4],
+            'lines': [100, 200],
+            'names': ['Container', 'Padding']
+          },
+          'package:flutter/src/material/scaffold.dart': {
+            'ids': [5],
+            'lines': [50],
+            'names': ['Scaffold']
+          },
+          'package:provider/src/provider.dart': {
+            'ids': [6],
+            'lines': [30],
+            'names': ['Provider']
+          },
+          'dart:ui/geometry.dart': {
+            'ids': [7],
+            'lines': [15],
+            'names': ['Offset']
           }
         }
-      })!;
+      });
+      if (parsed == null) {
+        throw StateError('Failed to parse mock Response');
+      }
+      return parsed;
     }
-    return vm_service.Response.parse({'type': 'Success'})!;
+    final parsed = vm_service.Response.parse({'type': 'Success'});
+    if (parsed == null) {
+      throw StateError('Failed to parse mock Response');
+    }
+    return parsed;
   }
 }
 
@@ -85,13 +122,14 @@ void main() {
   });
 
   group('RebuildTrackingSupport Tests', () {
-    test('get_counts respects topN and limits the printed output list',
+    test(
+        'Default filtering (exclude_flutter_widgets omitted) only returns project widgets',
         () async {
-      Future.delayed(const Duration(milliseconds: 100), () {
+      unawaited(Future.delayed(const Duration(milliseconds: 100), () {
         (mock.vmService! as FakeVmServiceForRebuilds).emitRebuildEvent({
-          'events': [1, 10, 2, 20, 3, 5]
+          'events': [1, 10, 2, 20, 3, 5, 5, 2, 6, 8, 7, 4]
         });
-      });
+      }));
 
       final result = await mock.callTool(
         CallToolRequest(
@@ -99,16 +137,386 @@ void main() {
           arguments: const {
             'action': 'get_counts',
             'duration_seconds': 1,
-            'topN': 2,
           },
         ),
       );
 
       expect(result.isError, isNot(isTrue));
       final text = (result.content.first as TextContent).text;
-      expect(text, contains('BWidget'));
-      expect(text, contains('AWidget'));
-      expect(text, isNot(contains('CWidget')));
+      expect(text, contains('AppScreen'));
+      expect(text, contains('MyWidget'));
+      expect(text, isNot(contains('Container')));
+      expect(text, isNot(contains('Scaffold')));
+      expect(text, isNot(contains('Provider')));
+      expect(text, isNot(contains('Offset')));
+      expect(text, contains('Note: Built-in Flutter/SDK widgets excluded.'));
+    });
+
+    test('Explicit exclude_flutter_widgets: true only returns project widgets',
+        () async {
+      unawaited(Future.delayed(const Duration(milliseconds: 100), () {
+        (mock.vmService! as FakeVmServiceForRebuilds).emitRebuildEvent({
+          'events': [1, 10, 3, 5]
+        });
+      }));
+
+      final result = await mock.callTool(
+        CallToolRequest(
+          name: 'rebuild_tracking',
+          arguments: const {
+            'action': 'get_counts',
+            'duration_seconds': 1,
+            'exclude_flutter_widgets': true,
+          },
+        ),
+      );
+
+      expect(result.isError, isNot(isTrue));
+      final text = (result.content.first as TextContent).text;
+      expect(text, contains('MyWidget'));
+      expect(text, isNot(contains('Container')));
+    });
+
+    test(
+        'Explicit exclude_flutter_widgets: false returns all widgets including SDK and packages',
+        () async {
+      unawaited(Future.delayed(const Duration(milliseconds: 100), () {
+        (mock.vmService! as FakeVmServiceForRebuilds).emitRebuildEvent({
+          'events': [1, 10, 3, 5, 6, 8, 7, 2]
+        });
+      }));
+
+      final result = await mock.callTool(
+        CallToolRequest(
+          name: 'rebuild_tracking',
+          arguments: const {
+            'action': 'get_counts',
+            'duration_seconds': 1,
+            'exclude_flutter_widgets': false,
+          },
+        ),
+      );
+
+      expect(result.isError, isNot(isTrue));
+      final text = (result.content.first as TextContent).text;
+      expect(text, contains('MyWidget'));
+      expect(text, contains('Container'));
+      expect(text, contains('Provider'));
+      expect(text, contains('Offset'));
+      expect(text,
+          isNot(contains('Note: Built-in Flutter/SDK widgets excluded.')));
+    });
+
+    test('All SDK widgets filtered results in graceful empty message',
+        () async {
+      unawaited(Future.delayed(const Duration(milliseconds: 100), () {
+        (mock.vmService! as FakeVmServiceForRebuilds).emitRebuildEvent({
+          'events': [3, 5, 5, 2]
+        });
+      }));
+
+      final result = await mock.callTool(
+        CallToolRequest(
+          name: 'rebuild_tracking',
+          arguments: const {
+            'action': 'get_counts',
+            'duration_seconds': 1,
+            'exclude_flutter_widgets': true,
+          },
+        ),
+      );
+
+      expect(result.isError, isNot(isTrue));
+      final text = (result.content.first as TextContent).text;
+      expect(text, contains('No rebuilds captured.'));
+    });
+
+    test(
+        'Response contains total_recorded_widgets and filtered_count in JSON format',
+        () async {
+      mock.responseFormat = 'json';
+
+      unawaited(Future.delayed(const Duration(milliseconds: 100), () {
+        (mock.vmService! as FakeVmServiceForRebuilds).emitRebuildEvent({
+          'events': [1, 10, 3, 5, 6, 2]
+        });
+      }));
+
+      final result = await mock.callTool(
+        CallToolRequest(
+          name: 'rebuild_tracking',
+          arguments: const {
+            'action': 'get_counts',
+            'duration_seconds': 1,
+            'exclude_flutter_widgets': true,
+          },
+        ),
+      );
+
+      expect(result.isError, isNot(isTrue));
+      final text = (result.content.first as TextContent).text;
+      expect(text, contains('total_recorded_widgets'));
+      expect(text, contains('filtered_count'));
+
+      final data = jsonDecode(
+              text.replaceFirst('```json\n', '').replaceFirst('\n```', ''))
+          as Map<String, dynamic>;
+      expect(data['total_recorded_widgets'], 3);
+      expect(data['filtered_count'], 1);
+    });
+
+    test(
+        'Start/stop flow with exclude_flutter_widgets: true only returns project widgets',
+        () async {
+      // Start tracking
+      final startRes = await mock.callTool(
+        CallToolRequest(
+          name: 'rebuild_tracking',
+          arguments: const {
+            'action': 'start',
+          },
+        ),
+      );
+      expect(startRes.isError, isNot(isTrue));
+
+      // Emit events
+      (mock.vmService! as FakeVmServiceForRebuilds).emitRebuildEvent({
+        'events': [1, 10, 3, 5]
+      });
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      // Stop tracking
+      final stopRes = await mock.callTool(
+        CallToolRequest(
+          name: 'rebuild_tracking',
+          arguments: const {
+            'action': 'stop',
+            'exclude_flutter_widgets': true,
+          },
+        ),
+      );
+
+      expect(stopRes.isError, isNot(isTrue));
+      final text = (stopRes.content.first as TextContent).text;
+      expect(text, contains('Filtered widgets: 1'));
+      expect(text, contains('MyWidget'));
+      expect(text, isNot(contains('Container')));
+    });
+
+    test(
+        'Start/stop flow with exclude_flutter_widgets: false returns all widgets',
+        () async {
+      // Start tracking
+      final startRes = await mock.callTool(
+        CallToolRequest(
+          name: 'rebuild_tracking',
+          arguments: const {
+            'action': 'start',
+          },
+        ),
+      );
+      expect(startRes.isError, isNot(isTrue));
+
+      // Emit events
+      (mock.vmService! as FakeVmServiceForRebuilds).emitRebuildEvent({
+        'events': [1, 10, 3, 5]
+      });
+      await Future<void>.delayed(const Duration(milliseconds: 100));
+
+      // Stop tracking
+      final stopRes = await mock.callTool(
+        CallToolRequest(
+          name: 'rebuild_tracking',
+          arguments: const {
+            'action': 'stop',
+            'exclude_flutter_widgets': false,
+          },
+        ),
+      );
+
+      expect(stopRes.isError, isNot(isTrue));
+      final text = (stopRes.content.first as TextContent).text;
+      expect(text, isNot(contains('Filtered widgets')));
+      expect(text, contains('MyWidget'));
+      expect(text, contains('Container'));
+    });
+
+    test('Helper isBuiltInWidget behaves correctly for all types of paths', () {
+      // Mock workspace root set
+      mock.workspaceRoot = '/Users/user/project';
+
+      // Project file
+      expect(
+          mock.isBuiltInWidget('/Users/user/project/lib/main.dart:10',
+              projectName: 'my_app'),
+          isFalse);
+
+      // Standard packages URIs
+      expect(
+          mock.isBuiltInWidget('package:flutter/src/widgets/container.dart:100',
+              projectName: 'my_app'),
+          isTrue);
+      expect(
+          mock.isBuiltInWidget('package:flutter_test/src/widget_tester.dart:12',
+              projectName: 'my_app'),
+          isTrue);
+      expect(
+          mock.isBuiltInWidget('package:provider/src/provider.dart:30',
+              projectName: 'my_app'),
+          isTrue);
+
+      // User package unresolved path
+      expect(
+          mock.isBuiltInWidget('package:my_app/main.dart:10',
+              projectName: 'my_app'),
+          isFalse);
+
+      // Puro, FVM, Mise, pub-cache paths
+      expect(
+          mock.isBuiltInWidget(
+              '/Users/user/.puro/envs/stable/flutter/packages/flutter/lib/src/widgets/basic.dart:50',
+              projectName: 'my_app'),
+          isTrue);
+      expect(
+          mock.isBuiltInWidget(
+              '/Users/user/.fvm/flutter_sdk/packages/flutter/lib/src/widgets/basic.dart:50',
+              projectName: 'my_app'),
+          isTrue);
+      expect(
+          mock.isBuiltInWidget(
+              '/Users/user/fvm/versions/3.22.0/packages/flutter/lib/src/widgets/basic.dart:50',
+              projectName: 'my_app'),
+          isTrue);
+      expect(
+          mock.isBuiltInWidget(
+              '/Users/user/.mise/installs/flutter/3.22.0/packages/flutter/lib/src/widgets/basic.dart:50',
+              projectName: 'my_app'),
+          isTrue);
+      expect(
+          mock.isBuiltInWidget(
+              '/Users/user/.pub-cache/hosted/pub.dev/provider-6.1.2/lib/provider.dart:10',
+              projectName: 'my_app'),
+          isTrue);
+
+      // Sky engine
+      expect(
+          mock.isBuiltInWidget(
+              '/Users/user/flutter/bin/cache/pkg/sky_engine/lib/ui/geometry.dart:10',
+              projectName: 'my_app'),
+          isTrue);
+
+      // dart: and org-dartlang-sdk: schemes
+      expect(
+          mock.isBuiltInWidget('dart:ui/geometry.dart:10',
+              projectName: 'my_app'),
+          isTrue);
+      expect(
+          mock.isBuiltInWidget(
+              'org-dartlang-sdk:///flutter/lib/src/widgets/basic.dart:5',
+              projectName: 'my_app'),
+          isTrue);
+
+      // Path outside workspace
+      expect(
+          mock.isBuiltInWidget('/Users/user/another_project/lib/helper.dart:15',
+              projectName: 'my_app'),
+          isTrue);
+
+      // Relative path check
+      expect(
+          mock.isBuiltInWidget('/Users/user/project/lib/../lib/main.dart:10',
+              projectName: 'my_app'),
+          isFalse);
+    });
+
+    test(
+        'Helper isBuiltInWidget falls back gracefully when workspaceRoot is null',
+        () {
+      mock.workspaceRoot = null;
+
+      // Project unresolved package URI
+      expect(
+          mock.isBuiltInWidget('package:my_app/main.dart:10',
+              projectName: 'my_app'),
+          isFalse);
+
+      // Flutter package URI
+      expect(
+          mock.isBuiltInWidget('package:flutter/src/widgets/container.dart:100',
+              projectName: 'my_app'),
+          isTrue);
+
+      // Standard dependency package URI
+      expect(
+          mock.isBuiltInWidget('package:provider/src/provider.dart:30',
+              projectName: 'my_app'),
+          isTrue);
+
+      // Local relative path structure
+      expect(
+          mock.isBuiltInWidget('/Users/user/project/lib/main.dart:10',
+              projectName: 'my_app'),
+          isFalse);
+
+      // Known pub-cache / puro path checks
+      expect(
+          mock.isBuiltInWidget(
+              '/Users/user/.pub-cache/hosted/pub.dev/provider-6.1.2/lib/provider.dart:10',
+              projectName: 'my_app'),
+          isTrue);
+    });
+
+    test('Helper isBuiltInWidget dynamically respects packageResolver', () {
+      mock.workspaceRoot = '/Users/user/project';
+      mock.isBuiltInWidgetCache.clear();
+
+      // Set up resolver with known local and external packages
+      final resolver = WorkspacePackageResolver('/Users/user/project');
+      resolver.addLocalPackage('my_app');
+      resolver.addLocalPackage('local_package');
+      resolver.addExternalPackage('provider');
+      resolver.addExternalPackage('flutter_animate');
+      mock.packageResolver = resolver;
+
+      // Local packages
+      expect(
+          mock.isBuiltInWidget('package:my_app/main.dart:10',
+              projectName: 'some_other_name'),
+          isFalse);
+      expect(
+          mock.isBuiltInWidget('package:local_package/widgets/button.dart:42',
+              projectName: 'some_other_name'),
+          isFalse);
+
+      // External packages
+      expect(
+          mock.isBuiltInWidget('package:provider/provider.dart:5',
+              projectName: 'some_other_name'),
+          isTrue);
+      expect(
+          mock.isBuiltInWidget('package:flutter_animate/animate.dart:2',
+              projectName: 'some_other_name'),
+          isTrue);
+    });
+
+    test(
+        'Helper isBuiltInWidget handles relative paths and optimizes cache key representation',
+        () {
+      mock.workspaceRoot = '/Users/user/project';
+      mock.isBuiltInWidgetCache.clear();
+
+      // Relative paths should resolve to absolute workspace paths and be treated as local
+      expect(mock.isBuiltInWidget('lib/main.dart:10', projectName: 'my_app'),
+          isFalse);
+      expect(
+          mock.isBuiltInWidget('src/widgets/button.dart:42',
+              projectName: 'my_app'),
+          isFalse);
+
+      // Verify line numbers are stripped from cache keys
+      expect(mock.isBuiltInWidgetCache.containsKey('lib/main.dart'), isTrue);
+      expect(
+          mock.isBuiltInWidgetCache.containsKey('lib/main.dart:10'), isFalse);
     });
   });
 }


### PR DESCRIPTION
Closes #10

This PR implements server-side filtering of built-in Flutter and SDK widgets from the rebuild tracking report, addressing the noise in the output when internal SDK widgets rebuild.

### Key Changes
* **`rebuild_tracking` Tool Argument**: Added optional `exclude_flutter_widgets` parameter (defaults to `true`).
* **Workspace Resolution**: Added `WorkspacePackageResolver` to parse `.dart_tool/package_config.json` and isolate local vs external package files.
* **Path Filtering**: Updated `isBuiltInWidget` in `VmConnectionSupport` to filter out SDK components, `.puro`, `.fvm`, and `.pub-cache` directories.
* **Output Format & Notice**: Appended a warning note when filters are active, and updated the JSON response to return `"total_recorded_widgets"` and `"filtered_count"`.
* **Tests**: Added coverage for path parsing, caching, and filter parameters in `rebuild_tracking_test.dart`.

---

## Verification Results

* **Unit Tests**: All 115 tests passed (`dart test`).
* **Integration Run**: Live verification completed against the PassVault app on the simulator. JSON and Markdown outputs confirm successful filtering and formatting updates.
