### PR TITLE
feat(network): add get_request_details action to network tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+- Added `get_request_details` action to `network` composite tool for detailed inspection of HTTP request/response headers, cookies, timing, and decoded body payloads.
+
 ## 1.6.2
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This server groups functions into action-based tools to keep the schema footprin
 | **Memory** | `memory` | `get_snapshot`, `save`, `compare`, `list`, `audit_leak`, `diff_allocations`, `get_referrers` | Monitor heap, save snapshots, diff allocations, find memory leaks, and trace object references. |
 | **Diagnostics** | `profiling` | `start`, `stop`, `get_cpu`, `diagnose_jank` | Track render times, find CPU hotspots, and diagnose UI lag. |
 | | `rebuild_tracking` | `start`, `stop`, `get_counts` | Track widget rebuild cycles and counts. |
-| **Logs & Network** | `network` | `start`, `stop`, `get_profile` | Capture HTTP network calls, start or stop network logging. |
+| **Logs & Network** | `network` | `start`, `stop`, `get_profile`, `get_request_details` | Capture HTTP network calls, inspect request headers, cookies, and bodies. |
 | | `fetch_console_logs` | *N/A* | Read stdout, stderr, and developer logs. |
 | | `trigger_scroll_gesture` | *N/A* | Scroll the application viewport. |
 | **Widget Inspector** | `widget` | `inspect`, `toggle_selection`, `get_tree` | Find widget tree structure, get layout details, and toggle device inspector. |

--- a/lib/src/mixins/network_capture_support.dart
+++ b/lib/src/mixins/network_capture_support.dart
@@ -26,11 +26,17 @@ base mixin NetworkCaptureSupport
         name: McpTool.network.name,
         description: 'Manage HTTP network capture. '
             'Actions: start (begin capture), stop (end and get report), '
-            'get_profile (read HTTP request history).',
+            'get_profile (read HTTP request history), '
+            'get_request_details (inspect full headers, cookies, timing, and body for a request).',
         inputSchema: ObjectSchema(
           properties: {
             'action': StringSchema(
-              description: 'Action to perform: start, stop, get_profile.',
+              description:
+                  'Action to perform: start, stop, get_profile, get_request_details.',
+            ),
+            'requestId': StringSchema(
+              description:
+                  'Request ID to inspect for get_request_details action.',
             ),
             'sortBy': StringSchema(
               description: 'Sort by: time, duration, size (for stop action).',
@@ -511,6 +517,206 @@ base mixin NetworkCaptureSupport
     );
   }
 
+  /// Handles the get_request_details tool request.
+  Future<CallToolResult> _handleGetHttpRequestDetails(
+      CallToolRequest req) async {
+    final requestId =
+        req.arg<String>('requestId') ?? req.arg<String>('request_id');
+
+    if (vmService == null) return notConnected();
+
+    if (!await _checkHttpProfileSupport()) {
+      return _getUnsupportedError();
+    }
+
+    Map<String, dynamic>? targetRequest;
+    final vm = vmService!;
+    final isoId = isolateId!;
+
+    // If requestId is specified, try fetching that specific request via ext.dart.io.getHttpProfileRequest
+    if (requestId != null && requestId.isNotEmpty && requestId != 'latest') {
+      stderr.writeln(
+          '[mcp:network_details] Fetching request details for ID $requestId...');
+      try {
+        final response = await vm.callServiceExtension(
+          'ext.dart.io.getHttpProfileRequest',
+          isolateId: isoId,
+          args: {'id': requestId},
+        );
+        final jsonMap = response.json ?? {};
+        final rawResult = jsonMap['result'];
+        if (rawResult is Map) {
+          targetRequest = _sanitizeRequest(rawResult);
+        } else if (jsonMap.containsKey('request')) {
+          targetRequest = _sanitizeRequest(jsonMap);
+        }
+      } catch (_) {}
+    }
+
+    // Fallback: search getHttpProfile list (or pick the latest request if requestId is missing/latest)
+    if (targetRequest == null) {
+      final allRequests = await _getHttpRequests();
+      if (allRequests.isNotEmpty) {
+        if (requestId == null || requestId.isEmpty || requestId == 'latest') {
+          stderr.writeln(
+              '[mcp:network_details] Auto-selecting most recent HTTP request...');
+          targetRequest = allRequests.last;
+        } else {
+          for (final r in allRequests) {
+            if (r['id']?.toString() == requestId) {
+              targetRequest = r;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    if (targetRequest == null) {
+      final msg =
+          (requestId == null || requestId.isEmpty || requestId == 'latest')
+              ? 'No HTTP requests recorded in VM profile history.'
+              : 'Request with ID `$requestId` was not found.';
+      return CallToolResult(
+        content: [TextContent(text: msg)],
+        isError: true,
+      );
+    }
+
+    final id = targetRequest['id']?.toString() ?? requestId;
+    final method = targetRequest['method']?.toString() ?? 'N/A';
+    final uri = targetRequest['uri']?.toString() ?? 'N/A';
+
+    final rawReq = targetRequest['request'];
+    final reqData = rawReq is Map ? Map<String, dynamic>.from(rawReq) : null;
+    final rawRes = targetRequest['response'];
+    final resData = rawRes is Map ? Map<String, dynamic>.from(rawRes) : null;
+
+    final statusCode = resData?['statusCode']?.toString() ?? 'Pending';
+    final reasonPhrase = resData?['reasonPhrase']?.toString() ?? '';
+    final statusStr =
+        reasonPhrase.isNotEmpty ? '$statusCode $reasonPhrase' : statusCode;
+
+    final startUs = targetRequest['startTime'] as int?;
+    final endUs = targetRequest['endTime'] as int?;
+    String durationStr = 'Pending';
+    double? durationMs;
+    if (startUs != null && endUs != null) {
+      durationMs = (endUs - startUs) / 1000.0;
+      durationStr = '${durationMs.toStringAsFixed(1)} ms';
+    }
+
+    String startTimeStr = 'Unknown';
+    if (startUs != null) {
+      final dt = DateTime.fromMicrosecondsSinceEpoch(startUs);
+      startTimeStr = dt.toIso8601String();
+    }
+
+    final rawReqHeaders = reqData?['headers'];
+    final reqHeaders = rawReqHeaders is Map
+        ? Map<String, dynamic>.from(rawReqHeaders)
+        : <String, dynamic>{};
+    final rawResHeaders = resData?['headers'];
+    final resHeaders = rawResHeaders is Map
+        ? Map<String, dynamic>.from(rawResHeaders)
+        : <String, dynamic>{};
+    final reqCookies = reqData?['cookies'] as List<dynamic>? ?? [];
+    final resCookies = resData?['cookies'] as List<dynamic>? ?? [];
+
+    final reqBodyRaw = reqData?['body'];
+    final resBodyRaw = resData?['body'];
+
+    String formatBody(dynamic raw) {
+      if (raw == null) return 'N/A';
+      if (raw is String) {
+        try {
+          final parsed = jsonDecode(raw);
+          return const JsonEncoder.withIndent('  ').convert(parsed);
+        } catch (_) {
+          return raw;
+        }
+      }
+      if (raw is Map || raw is List) {
+        return const JsonEncoder.withIndent('  ').convert(raw);
+      }
+      return raw.toString();
+    }
+
+    final md = StringBuffer();
+    md.writeln('HTTP Request Details $id');
+    md.writeln('Method: $method');
+    md.writeln('URI: $uri');
+    md.writeln('Status: $statusStr');
+    md.writeln('Duration: $durationStr');
+    md.writeln('Start Time: $startTimeStr');
+
+    final error = targetRequest['error']?.toString();
+    if (error != null && error.isNotEmpty) {
+      md.writeln('Error: $error');
+    }
+
+    if (reqHeaders.isNotEmpty) {
+      md.writeln('Request Headers:');
+      reqHeaders.forEach((k, v) => md.writeln('$k: $v'));
+    }
+
+    if (reqCookies.isNotEmpty) {
+      md.writeln('Request Cookies:');
+      for (final c in reqCookies) {
+        md.writeln(c.toString());
+      }
+    }
+
+    final formattedReqBody = formatBody(reqBodyRaw);
+    if (formattedReqBody != 'N/A' && formattedReqBody.isNotEmpty) {
+      md.writeln('Request Body:');
+      md.writeln(formattedReqBody);
+    }
+
+    if (resHeaders.isNotEmpty) {
+      md.writeln('Response Headers:');
+      resHeaders.forEach((k, v) => md.writeln('$k: $v'));
+    }
+
+    if (resCookies.isNotEmpty) {
+      md.writeln('Response Cookies:');
+      for (final c in resCookies) {
+        md.writeln(c.toString());
+      }
+    }
+
+    final formattedResBody = formatBody(resBodyRaw);
+    if (formattedResBody != 'N/A' && formattedResBody.isNotEmpty) {
+      md.writeln('Response Body:');
+      md.writeln(formattedResBody);
+    }
+
+    return serializeDualFormat(
+      title: 'HTTP Request Details $id',
+      markdownBody: md.toString(),
+      structuredData: {
+        'id': id,
+        'method': method,
+        'uri': uri,
+        'statusCode': statusCode,
+        'reasonPhrase': reasonPhrase,
+        'duration_ms': durationMs,
+        'startTime': startTimeStr,
+        'error': error,
+        'request': {
+          'headers': reqHeaders,
+          'cookies': reqCookies,
+          'body': reqBodyRaw,
+        },
+        'response': {
+          'headers': resHeaders,
+          'cookies': resCookies,
+          'body': resBodyRaw,
+        },
+      },
+    );
+  }
+
   /// Handles the network composite tool request.
   Future<CallToolResult> _handleNetwork(CallToolRequest req) async {
     final action = req.requireArg<String>('action');
@@ -518,6 +724,7 @@ base mixin NetworkCaptureSupport
       'start' => _handleStartNetworkCapture(req),
       'stop' => _handleStopNetworkCapture(req),
       'get_profile' => _handleGetNetworkProfile(req),
+      'get_request_details' => _handleGetHttpRequestDetails(req),
       _ => CallToolResult(
           content: [TextContent(text: 'Unknown network action: $action')],
           isError: true,

--- a/test/unit/network_request_details_test.dart
+++ b/test/unit/network_request_details_test.dart
@@ -1,0 +1,202 @@
+import 'dart:async';
+import 'package:dart_mcp/server.dart';
+import 'package:flutter_agent_lens/src/mixins/network_capture_support.dart';
+import 'package:flutter_agent_lens/src/mixins/vm_connection_support.dart';
+import 'package:stream_channel/stream_channel.dart';
+import 'package:test/test.dart';
+import 'package:vm_service/vm_service.dart' as vm_service;
+
+base class NetworkDetailsMock extends MCPServer
+    with ToolsSupport, VmConnectionSupport, NetworkCaptureSupport {
+  NetworkDetailsMock(super.channel)
+      : super.fromStreamChannel(
+          implementation: Implementation(name: 'mock', version: '1.0'),
+        );
+
+  @override
+  void registerConnectedTools() {}
+
+  @override
+  void unregisterConnectedTools() {}
+}
+
+class FakeVmServiceForRequestDetails extends vm_service.VmService {
+  final Map<String, dynamic> requestDetailsResponse;
+  final bool supportExtension;
+
+  FakeVmServiceForRequestDetails(
+    this.requestDetailsResponse, {
+    this.supportExtension = true,
+  }) : super(const Stream<dynamic>.empty(), (msg) {});
+
+  @override
+  Future<vm_service.Isolate> getIsolate(String isolateId) async {
+    return vm_service.Isolate(
+      id: 'isolate_1',
+      name: 'main',
+      extensionRPCs: supportExtension ? ['ext.dart.io.getHttpProfile'] : [],
+    );
+  }
+
+  @override
+  Future<vm_service.Response> callServiceExtension(
+    String method, {
+    String? isolateId,
+    Map<String, dynamic>? args,
+  }) async {
+    if (method == 'ext.dart.io.getHttpProfileRequest' ||
+        method == 'ext.dart.io.getHttpProfile') {
+      return vm_service.Response.parse(requestDetailsResponse)!;
+    }
+    return vm_service.Response.parse({})!;
+  }
+}
+
+void main() {
+  late StreamChannelController<String> controller;
+  late NetworkDetailsMock mock;
+
+  setUp(() {
+    controller = StreamChannelController<String>();
+    mock = NetworkDetailsMock(controller.local);
+    mock.registerNetworkTools();
+    mock.isolateId = 'isolate_1';
+  });
+
+  group('get_request_details action tests', () {
+    test('returns error when profile history is empty and requestId is omitted',
+        () async {
+      mock.vmService = FakeVmServiceForRequestDetails({
+        'result': {
+          'requests': <Map<String, dynamic>>[],
+        }
+      });
+
+      final result = await mock.callTool(
+        CallToolRequest(
+          name: 'network',
+          arguments: const {'action': 'get_request_details'},
+        ),
+      );
+
+      expect(result.isError, isTrue);
+      expect(
+        (result.content.first as TextContent).text,
+        contains('No HTTP requests recorded in VM profile history'),
+      );
+    });
+
+    test('auto-selects most recent request when requestId is omitted',
+        () async {
+      mock.vmService = FakeVmServiceForRequestDetails({
+        'result': {
+          'requests': [
+            {
+              'id': '999',
+              'method': 'GET',
+              'uri': 'https://api.example.com/auto-latest',
+              'startTime': 1000000,
+              'endTime': 1200000,
+              'request': {
+                'headers': <String, dynamic>{},
+                'cookies': <dynamic>[],
+              },
+              'response': {
+                'statusCode': 200,
+                'headers': <String, dynamic>{},
+                'cookies': <dynamic>[],
+              },
+            }
+          ]
+        }
+      });
+
+      final result = await mock.callTool(
+        CallToolRequest(
+          name: 'network',
+          arguments: const {'action': 'get_request_details'},
+        ),
+      );
+
+      expect(result.isError ?? false, isFalse);
+      expect(
+        (result.content.first as TextContent).text,
+        contains('https://api.example.com/auto-latest'),
+      );
+    });
+
+    test('returns error when HTTP profile extension is unsupported', () async {
+      mock.vmService = FakeVmServiceForRequestDetails(
+        {},
+        supportExtension: false,
+      );
+
+      final result = await mock.callTool(
+        CallToolRequest(
+          name: 'network',
+          arguments: const {
+            'action': 'get_request_details',
+            'requestId': '101',
+          },
+        ),
+      );
+
+      expect(result.isError, isTrue);
+      expect(
+        (result.content.first as TextContent).text,
+        contains('Network profiling via the Dart VM Service is not supported'),
+      );
+    });
+
+    test('retrieves full request and response details successfully', () async {
+      mock.vmService = FakeVmServiceForRequestDetails({
+        'result': {
+          'id': '101',
+          'method': 'POST',
+          'uri': 'https://api.example.com/users/create',
+          'startTime': 1000000,
+          'endTime': 1250000,
+          'request': {
+            'headers': {
+              'content-type': 'application/json',
+              'authorization': 'Bearer token123'
+            },
+            'cookies': ['session=xyz123'],
+            'contentLength': 42,
+            'body': '{"name":"John Doe","email":"john@example.com"}',
+          },
+          'response': {
+            'statusCode': 201,
+            'reasonPhrase': 'Created',
+            'headers': {'content-type': 'application/json; charset=utf-8'},
+            'cookies': ['logged_in=true'],
+            'contentLength': 58,
+            'body': '{"id":101,"status":"success","message":"User created"}',
+          },
+        }
+      });
+
+      final result = await mock.callTool(
+        CallToolRequest(
+          name: 'network',
+          arguments: const {
+            'action': 'get_request_details',
+            'requestId': '101',
+          },
+        ),
+      );
+
+      expect(result.isError, isNot(isTrue));
+      final text = (result.content.first as TextContent).text;
+
+      expect(text, contains('POST'));
+      expect(text, contains('https://api.example.com/users/create'));
+      expect(text, contains('201 Created'));
+      expect(text, contains('250.0 ms'));
+      expect(text, contains('authorization'));
+      expect(text, contains('session=xyz123'));
+      expect(text, contains('john@example.com'));
+      expect(text, contains('User created'));
+    });
+  });
+}


### PR DESCRIPTION
Fixes #7

### Summary of Changes

- Added `get_request_details` action to the composite `network` MCP tool.
- Supports querying complete request and response metadata (headers, cookies, status code, duration, decoded request/response bodies) via VM Service protocol `ext.dart.io.getHttpProfileRequest` (with fallback to `getHttpProfile`).
- Added optional `requestId` handling; when omitted or set to `'latest'`, automatically selects the most recent HTTP call recorded by the VM.
- Added comprehensive unit test coverage in `test/unit/network_request_details_test.dart`.
- Updated `CHANGELOG.md` under `## Unreleased`.
