### PR TITLE
feat(memory): implement Memory Timeline, GC stream monitoring, and force_gc tools (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 ## Unreleased
 
+
 ### Added
 - Added `get_request_details` action to `network` composite tool for detailed inspection of HTTP request/response headers, cookies, timing, and decoded body payloads.
+- Added 6 new memory tool actions (`force_gc`, `start_gc_stream`, `stop_gc_stream`, `get_memory_timeline`, `watch_gc_pressure`, `explain_memory_breakdown`) to `memory` composite tool.
+
 
 ## 1.6.2
+
 
 ### Added
 - Added `get_navigation_stack` MCP tool to inspect active routes, current URL, and nested navigator trees via the Dart VM Service.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This server groups functions into action-based tools to keep the schema footprin
 | :--- | :--- | :--- | :--- |
 | **App Info** | `get_app_info` | *N/A* | Get VM version details, isolates, and service extensions. |
 | **DTD Integration**| `get_active_location`| *N/A* | Find active editor path and cursor line (requires DTD). |
-| **Memory** | `memory` | `get_snapshot`, `save`, `compare`, `list`, `audit_leak`, `diff_allocations`, `get_referrers` | Monitor heap, save snapshots, diff allocations, find memory leaks, and trace object references. |
+| **Memory** | `memory` | `get_snapshot`, `save`, `compare`, `list`, `audit_leak`, `diff_allocations`, `get_referrers`, `force_gc`, `start_gc_stream`, `stop_gc_stream`, `get_memory_timeline`, `watch_gc_pressure`, `explain_memory_breakdown` | Monitor heap, save snapshots, diff allocations, find memory leaks, trigger GC, stream GC events, sample memory timelines, and trace object references. |
 | **Diagnostics** | `profiling` | `start`, `stop`, `get_cpu`, `diagnose_jank` | Track render times, find CPU hotspots, and diagnose UI lag. |
 | | `rebuild_tracking` | `start`, `stop`, `get_counts` | Track widget rebuild cycles and counts. |
 | **Logs & Network** | `network` | `start`, `stop`, `get_profile`, `get_request_details` | Capture HTTP network calls, inspect request headers, cookies, and bodies. |
@@ -95,10 +95,12 @@ To keep payloads light, these settings are supported:
   - `limit` in `profiling` (action: `diagnose_jank`): Sets max frames returned (default: `15`).
   - `limit` in `profiling` (action: `get_cpu`): Sets max CPU hotspots returned (default: `15`).
   - `limit` in `diagnose_project` (action: `bundle_size`): Sets max components shown (default: `25`).
-  - `limit` in `memory` (action: `audit_leak` or `get_referrers`): Sets max instances/references to return.
+  - `limit` in `memory` (action: `audit_leak`, `get_referrers`, `stop_gc_stream`, `watch_gc_pressure`): Sets max instances, path depth, or returned GC events (default: `50`-`100`).
+  - `duration_seconds` in `memory` (action: `get_memory_timeline`, `watch_gc_pressure`): Sets sampling or monitoring duration in seconds (default: `5`-`10`, max: `60`).
   - `topN` in `memory` (action: `compare`): Sets max class differences returned (default: `10`).
   - `topN` in `memory` (action: `get_snapshot`): Sets max classes by size (default: `20`).
   - `topN` in `rebuild_tracking` (action: `stop` / `get_counts`): Sets max rebuild entries shown (default: `30`).
+
 
 - **Layout Controls**:
   - `maxDepth` in `widget` (action: `get_tree`): Sets widget tree depth (default: `8`).

--- a/lib/src/mixins/memory_debugging_support.dart
+++ b/lib/src/mixins/memory_debugging_support.dart
@@ -15,21 +15,39 @@ base mixin MemoryDebuggingSupport
   /// Named cache of taken memory snapshots.
   final Map<String, MemorySnapshot> memorySnapshots = {};
 
+  /// Subscription to the VM Service's GC event stream.
+  StreamSubscription<Event>? _gcStreamSub;
+
+  /// Ring buffer of collected GC events (max 500).
+  final List<Map<String, dynamic>> _gcEventBuffer = [];
+
+  /// Whether GC stream monitoring is currently active.
+  bool _gcStreamActive = false;
+
+  /// Timestamp in milliseconds when GC stream monitoring started.
+  int? _gcStreamStartTime;
+
   /// Registers all memory debugging and profiling tools.
   void registerMemoryTools() {
     registerTool(
       Tool(
         name: McpTool.memory.name,
         description:
-            'Manage memory snapshots, heap diffs, class memory audits, and retaining path traces. '
+            'Manage memory snapshots, heap diffs, class memory audits, retaining path traces, '
+            'GC triggers, GC streams, memory timelines, and memory explanations. '
             'Actions: get_snapshot (heap overview), save (named snapshot), compare (diff two snapshots), '
             'list (show saved), audit_leak (inspect class instances), diff_allocations (delta heap over time), '
-            'get_referrers (trace object retaining path).',
+            'get_referrers (trace object retaining path), force_gc (trigger GC & report freed memory), '
+            'start_gc_stream (subscribe to GC events), stop_gc_stream (end GC subscription & get events), '
+            'get_memory_timeline (record RSS/heap/GC over duration), watch_gc_pressure (monitor GC frequency), '
+            'explain_memory_breakdown (plain English RSS/heap/external/raster overview).',
         inputSchema: ObjectSchema(
           properties: {
             'action': StringSchema(
               description:
-                  'The memory action: get_snapshot, save, compare, list, audit_leak, diff_allocations, get_referrers.',
+                  'The memory action: get_snapshot, save, compare, list, audit_leak, diff_allocations, '
+                  'get_referrers, force_gc, start_gc_stream, stop_gc_stream, get_memory_timeline, '
+                  'watch_gc_pressure, explain_memory_breakdown.',
             ),
             'name': StringSchema(description: 'Snapshot name (for save).'),
             'before':
@@ -69,9 +87,79 @@ base mixin MemoryDebuggingSupport
     );
   }
 
-  /// Disposes and clears all saved memory snapshots.
+  /// Disposes and clears all saved memory snapshots and stream subscriptions.
   void cleanupMemoryDebugging() {
     memorySnapshots.clear();
+    unawaited(_gcStreamSub?.cancel());
+    _gcStreamSub = null;
+    _gcEventBuffer.clear();
+    _gcStreamActive = false;
+    _gcStreamStartTime = null;
+  }
+
+  /// Helper to fetch heap usage stats from [AllocationProfile].
+  Future<({int heapUsage, int heapCapacity, int externalUsage})> _getHeapStats({
+    bool gc = false,
+  }) async {
+    final profile = await vmService!.getAllocationProfile(isolateId!, gc: gc);
+    return (
+      heapUsage: profile.memoryUsage?.heapUsage ?? 0,
+      heapCapacity: profile.memoryUsage?.heapCapacity ?? 0,
+      externalUsage: profile.memoryUsage?.externalUsage ?? 0,
+    );
+  }
+
+  /// Helper to fetch total RSS process memory in bytes.
+  Future<int> _getRssBytes() async {
+    try {
+      final usage = await vmService!.getProcessMemoryUsage();
+      return usage.root?.size ?? 0;
+    } catch (_) {
+      return 0;
+    }
+  }
+
+  /// Ensures subscription to EventStreams.kGC is active.
+  Future<void> _ensureGcStream() async {
+    if (_gcStreamActive) return;
+    try {
+      await vmService!.streamListen(EventStreams.kGC);
+    } catch (e) {
+      if (e is! RPCError || e.code != 103) {
+        rethrow;
+      }
+    }
+    await _gcStreamSub?.cancel();
+    _gcStreamSub = vmService!.onGCEvent.listen((Event event) {
+      final item = <String, dynamic>{
+        'kind': event.kind ?? 'GC',
+        'timestamp': event.timestamp ?? DateTime.now().millisecondsSinceEpoch,
+        if (event.gcType != null) 'gcType': event.gcType,
+      };
+      if (event.json != null) {
+        final raw = event.json!;
+        if (raw.containsKey('reason')) item['reason'] = raw['reason'];
+        if (raw.containsKey('duration')) item['duration'] = raw['duration'];
+      }
+      _gcEventBuffer.add(item);
+      if (_gcEventBuffer.length > 500) {
+        _gcEventBuffer.removeAt(0);
+      }
+    });
+    _gcStreamActive = true;
+    _gcStreamStartTime = DateTime.now().millisecondsSinceEpoch;
+  }
+
+  /// Internal cleanup for GC event stream.
+  Future<void> _stopGcStreamInternal() async {
+    await _gcStreamSub?.cancel();
+    _gcStreamSub = null;
+    _gcStreamActive = false;
+    if (vmService != null) {
+      try {
+        await vmService!.streamCancel(EventStreams.kGC);
+      } catch (_) {}
+    }
   }
 
   /// Handles the audit_class_memory_leak tool request.
@@ -834,6 +922,315 @@ base mixin MemoryDebuggingSupport
     return md.toString();
   }
 
+  /// Handles the force_gc tool request.
+  Future<CallToolResult> _handleForceGc(CallToolRequest req) async {
+    final before = await _getHeapStats();
+    final after = await _getHeapStats(gc: true);
+
+    final freedBytes = before.heapUsage - after.heapUsage;
+    final freedPct = before.heapUsage > 0
+        ? (freedBytes / before.heapUsage * 100).toStringAsFixed(1)
+        : '0.0';
+
+    final text = StringBuffer()
+      ..writeln('| Metric | Before | After | Delta / Freed |')
+      ..writeln('| :--- | :--- | :--- | :--- |')
+      ..writeln(
+          '| **Heap Usage** | ${formatBytes(before.heapUsage)} | ${formatBytes(after.heapUsage)} | ${formatBytes(freedBytes)} ($freedPct% freed) |')
+      ..writeln(
+          '| **Heap Capacity** | ${formatBytes(before.heapCapacity)} | ${formatBytes(after.heapCapacity)} | ${formatBytes(after.heapCapacity - before.heapCapacity)} |')
+      ..writeln(
+          '| **External Usage** | ${formatBytes(before.externalUsage)} | ${formatBytes(after.externalUsage)} | ${formatBytes(after.externalUsage - before.externalUsage)} |');
+
+    final data = {
+      'action': 'force_gc',
+      'heap_before': before.heapUsage,
+      'heap_after': after.heapUsage,
+      'freed_bytes': freedBytes,
+      'freed_percentage': freedPct,
+      'capacity_before': before.heapCapacity,
+      'capacity_after': after.heapCapacity,
+      'external_before': before.externalUsage,
+      'external_after': after.externalUsage,
+    };
+
+    return serializeDualFormat(
+      title: '### Garbage Collection (force_gc) Result',
+      markdownBody: text.toString(),
+      structuredData: data,
+    );
+  }
+
+  /// Handles the start_gc_stream tool request.
+  Future<CallToolResult> _handleStartGcStream(CallToolRequest req) async {
+    await _ensureGcStream();
+    return serializeDualFormat(
+      title: '### GC Stream Monitoring Started',
+      markdownBody:
+          'Now collecting garbage collection events on stream `${EventStreams.kGC}`.',
+      structuredData: {
+        'action': 'start_gc_stream',
+        'status': 'active',
+        'start_timestamp': _gcStreamStartTime,
+      },
+    );
+  }
+
+  /// Handles the stop_gc_stream tool request.
+  Future<CallToolResult> _handleStopGcStream(CallToolRequest req) async {
+    final limit = req.arg<num>('limit')?.toInt() ?? 50;
+    final count = _gcEventBuffer.length;
+    final durationMs = _gcStreamStartTime != null
+        ? DateTime.now().millisecondsSinceEpoch - _gcStreamStartTime!
+        : 0;
+    final returnedEvents = _gcEventBuffer.take(limit).toList();
+
+    await _stopGcStreamInternal();
+
+    final text = StringBuffer()
+      ..writeln('- **Duration**: ${(durationMs / 1000).toStringAsFixed(1)}s')
+      ..writeln('- **Total Events Captured**: $count')
+      ..writeln('- **Events Returned**: ${returnedEvents.length}');
+
+    if (returnedEvents.isNotEmpty) {
+      text.writeln('\n#### Recent GC Events');
+      for (final e in returnedEvents) {
+        text.writeln(
+            '- Type: ${e['gcType'] ?? e['kind']} at ${e['timestamp']}');
+      }
+    }
+
+    final data = {
+      'action': 'stop_gc_stream',
+      'status': 'stopped',
+      'duration_ms': durationMs,
+      'total_events': count,
+      'events': returnedEvents,
+    };
+
+    _gcEventBuffer.clear();
+
+    return serializeDualFormat(
+      title: '### GC Stream Monitoring Stopped',
+      markdownBody: text.toString(),
+      structuredData: data,
+    );
+  }
+
+  /// Handles the get_memory_timeline tool request.
+  Future<CallToolResult> _handleGetMemoryTimeline(CallToolRequest req) async {
+    final rawDuration = req.arg<num>('duration_seconds')?.toInt() ?? 5;
+    final duration = rawDuration.clamp(1, 60);
+
+    final wasActive = _gcStreamActive;
+    if (!wasActive) {
+      await _ensureGcStream();
+    }
+
+    final samples = <MemoryTimelineSample>[];
+    final startEventCount = _gcEventBuffer.length;
+    var lastCheckEventCount = startEventCount;
+
+    for (var i = 0; i <= duration; i++) {
+      if (i > 0) {
+        await Future<void>.delayed(const Duration(seconds: 1));
+      }
+      final heap = await _getHeapStats();
+      final rss = await _getRssBytes();
+      final currentEventCount = _gcEventBuffer.length;
+      final gcInInterval = currentEventCount - lastCheckEventCount;
+      lastCheckEventCount = currentEventCount;
+
+      samples.add(MemoryTimelineSample(
+        timestamp: DateTime.now().millisecondsSinceEpoch,
+        heapUsed: heap.heapUsage,
+        heapCapacity: heap.heapCapacity,
+        externalUsage: heap.externalUsage,
+        rss: rss,
+        gcEventsInInterval: gcInInterval,
+      ));
+    }
+
+    if (!wasActive) {
+      await _stopGcStreamInternal();
+    }
+
+    final text = StringBuffer()
+      ..writeln(
+          '| Timestamp | Heap Used | Heap Capacity | External | RSS | GC Events |')
+      ..writeln('| :--- | :--- | :--- | :--- | :--- | :--- |');
+
+    for (final s in samples) {
+      final timeStr = DateTime.fromMillisecondsSinceEpoch(s.timestamp)
+          .toLocal()
+          .toString()
+          .split(' ')
+          .last
+          .split('.')
+          .first;
+      text.writeln(
+          '| $timeStr | ${formatBytes(s.heapUsed)} | ${formatBytes(s.heapCapacity)} | ${formatBytes(s.externalUsage)} | ${formatBytes(s.rss)} | ${s.gcEventsInInterval} |');
+    }
+
+    final data = {
+      'action': 'get_memory_timeline',
+      'duration_seconds': duration,
+      'sample_count': samples.length,
+      'samples': samples.map((s) => s.toMap()).toList(),
+    };
+
+    return serializeDualFormat(
+      title: '### Memory Timeline (${duration}s recording)',
+      markdownBody: text.toString(),
+      structuredData: data,
+    );
+  }
+
+  /// Handles the watch_gc_pressure tool request.
+  Future<CallToolResult> _handleWatchGcPressure(CallToolRequest req) async {
+    final rawDuration = req.arg<num>('duration_seconds')?.toInt() ?? 10;
+    final duration = rawDuration.clamp(1, 60);
+    final limit = req.arg<num>('limit')?.toInt() ?? 50;
+
+    final wasActive = _gcStreamActive;
+    if (!wasActive) {
+      await _ensureGcStream();
+    }
+
+    final startIndex = _gcEventBuffer.length;
+    await Future<void>.delayed(Duration(seconds: duration));
+
+    final newEvents = _gcEventBuffer.skip(startIndex).toList();
+    if (!wasActive) {
+      await _stopGcStreamInternal();
+    }
+
+    final gcCount = newEvents.length;
+    final gcPerSec = gcCount / duration;
+
+    String pressureLevel;
+    if (gcPerSec < 0.5) {
+      pressureLevel = 'low';
+    } else if (gcPerSec <= 2.0) {
+      pressureLevel = 'moderate';
+    } else {
+      pressureLevel = 'high';
+    }
+
+    // Inter-GC intervals
+    final intervals = <double>[];
+    for (var i = 1; i < newEvents.length; i++) {
+      final prev = newEvents[i - 1]['timestamp'] as int;
+      final curr = newEvents[i]['timestamp'] as int;
+      intervals.add((curr - prev) / 1000.0);
+    }
+    final avgInterval = intervals.isNotEmpty
+        ? (intervals.reduce((a, b) => a + b) / intervals.length)
+            .toStringAsFixed(2)
+        : 'N/A';
+
+    // gcType distribution
+    final typeCounts = <String, int>{};
+    for (final e in newEvents) {
+      final type = (e['gcType'] as String?) ?? 'Unknown';
+      typeCounts[type] = (typeCounts[type] ?? 0) + 1;
+    }
+
+    final text = StringBuffer()
+      ..writeln('- **Pressure Level**: `${pressureLevel.toUpperCase()}`')
+      ..writeln('- **GC Event Count**: $gcCount')
+      ..writeln('- **GC Frequency**: ${gcPerSec.toStringAsFixed(2)} GC/sec')
+      ..writeln('- **Avg Inter-GC Interval**: ${avgInterval}s');
+
+    if (typeCounts.isNotEmpty) {
+      text.writeln('- **GC Type Distribution**:');
+      typeCounts.forEach((type, count) {
+        text.writeln('  - $type: $count');
+      });
+    }
+
+    final returnedEvents = newEvents.take(limit).toList();
+
+    final data = {
+      'action': 'watch_gc_pressure',
+      'duration_seconds': duration,
+      'pressure_level': pressureLevel,
+      'gc_count': gcCount,
+      'gc_frequency_per_sec': gcPerSec,
+      'avg_interval_seconds': avgInterval,
+      'gc_type_distribution': typeCounts,
+      'events': returnedEvents,
+    };
+
+    return serializeDualFormat(
+      title: '### GC Pressure Analysis (${duration}s window)',
+      markdownBody: text.toString(),
+      structuredData: data,
+    );
+  }
+
+  /// Handles the explain_memory_breakdown tool request.
+  Future<CallToolResult> _handleExplainMemoryBreakdown(
+      CallToolRequest req) async {
+    final rss = await _getRssBytes();
+    final heap = await _getHeapStats();
+
+    int? rasterBytes;
+    try {
+      final rasterRes = await vmService!.callServiceExtension(
+        'ext.ui.window.getSkiaEstimateRasterCacheMemory',
+        isolateId: isolateId!,
+      );
+      final json = rasterRes.json;
+      if (json != null && json.containsKey('result')) {
+        rasterBytes = json['result'] as int?;
+      }
+    } catch (_) {
+      // Extension unavailable
+    }
+
+    final text = StringBuffer()
+      ..writeln('- **Resident Set Size (RSS)**: ${formatBytes(rss)}')
+      ..writeln(
+          '  _Total physical memory allocated to the application process by the operating system._')
+      ..writeln()
+      ..writeln(
+          '- **Dart Heap Used**: ${formatBytes(heap.heapUsage)} / ${formatBytes(heap.heapCapacity)} (${(heap.heapCapacity > 0 ? (heap.heapUsage / heap.heapCapacity * 100) : 0).toStringAsFixed(1)}% capacity)')
+      ..writeln(
+          '  _Memory managed directly by the Dart garbage collector for Dart objects._')
+      ..writeln()
+      ..writeln('- **External Memory**: ${formatBytes(heap.externalUsage)}')
+      ..writeln(
+          '  _Native memory bound to Dart objects (e.g. image bytes, native plugin buffers)._');
+
+    if (rasterBytes != null) {
+      text
+        ..writeln()
+        ..writeln('- **Raster Cache**: ${formatBytes(rasterBytes)}')
+        ..writeln(
+            '  _GPU memory reserved for rendered picture and image raster caches._');
+    } else {
+      text
+        ..writeln()
+        ..writeln('- **Raster Cache**: N/A (service extension unavailable)');
+    }
+
+    final data = {
+      'action': 'explain_memory_breakdown',
+      'rss_bytes': rss,
+      'heap_used_bytes': heap.heapUsage,
+      'heap_capacity_bytes': heap.heapCapacity,
+      'external_bytes': heap.externalUsage,
+      if (rasterBytes != null) 'raster_cache_bytes': rasterBytes,
+    };
+
+    return serializeDualFormat(
+      title: '### Memory Usage Breakdown',
+      markdownBody: text.toString(),
+      structuredData: data,
+    );
+  }
+
   /// Handles the memory composite tool request.
   Future<CallToolResult> _handleMemory(CallToolRequest req) async {
     final action = req.requireArg<String>('action');
@@ -848,6 +1245,12 @@ base mixin MemoryDebuggingSupport
       'audit_leak' => _handleAuditClassMemoryLeak(req),
       'diff_allocations' => _handleDiffHeapAllocations(req),
       'get_referrers' => _handleGetObjectReferrers(req),
+      'force_gc' => _handleForceGc(req),
+      'start_gc_stream' => _handleStartGcStream(req),
+      'stop_gc_stream' => _handleStopGcStream(req),
+      'get_memory_timeline' => _handleGetMemoryTimeline(req),
+      'watch_gc_pressure' => _handleWatchGcPressure(req),
+      'explain_memory_breakdown' => _handleExplainMemoryBreakdown(req),
       _ => CallToolResult(
           content: [TextContent(text: 'Unknown memory action: $action')],
           isError: true,

--- a/lib/src/models/memory_models.dart
+++ b/lib/src/models/memory_models.dart
@@ -146,3 +146,81 @@ final class MemorySnapshot {
     return true;
   }
 }
+
+/// Represents a single point-in-time memory sample for timeline recording.
+final class MemoryTimelineSample {
+  /// Creates a new [MemoryTimelineSample] instance.
+  const MemoryTimelineSample({
+    required this.timestamp,
+    required this.heapUsed,
+    required this.heapCapacity,
+    required this.externalUsage,
+    required this.rss,
+    required this.gcEventsInInterval,
+  });
+
+  /// Factory constructor to parse a [MemoryTimelineSample] from a Map.
+  factory MemoryTimelineSample.fromMap(Map<String, dynamic> map) {
+    return MemoryTimelineSample(
+      timestamp: (map['timestamp'] as num?)?.toInt() ?? 0,
+      heapUsed: (map['heap_used'] as num?)?.toInt() ?? 0,
+      heapCapacity: (map['heap_capacity'] as num?)?.toInt() ?? 0,
+      externalUsage: (map['external_usage'] as num?)?.toInt() ?? 0,
+      rss: (map['rss'] as num?)?.toInt() ?? 0,
+      gcEventsInInterval: (map['gc_events_in_interval'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  /// Millisecond timestamp of the sample.
+  final int timestamp;
+
+  /// Active heap usage in bytes.
+  final int heapUsed;
+
+  /// Total heap capacity in bytes.
+  final int heapCapacity;
+
+  /// External memory usage in bytes.
+  final int externalUsage;
+
+  /// Resident Set Size (RSS) process memory in bytes.
+  final int rss;
+
+  /// Number of GC events recorded since the previous sample.
+  final int gcEventsInInterval;
+
+  /// Serializes the timeline sample to a Map.
+  Map<String, dynamic> toMap() => {
+        'timestamp': timestamp,
+        'heap_used': heapUsed,
+        'heap_capacity': heapCapacity,
+        'external_usage': externalUsage,
+        'rss': rss,
+        'gc_events_in_interval': gcEventsInInterval,
+      };
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MemoryTimelineSample &&
+          timestamp == other.timestamp &&
+          heapUsed == other.heapUsed &&
+          heapCapacity == other.heapCapacity &&
+          externalUsage == other.externalUsage &&
+          rss == other.rss &&
+          gcEventsInInterval == other.gcEventsInInterval;
+
+  @override
+  int get hashCode => Object.hash(
+        timestamp,
+        heapUsed,
+        heapCapacity,
+        externalUsage,
+        rss,
+        gcEventsInInterval,
+      );
+
+  @override
+  String toString() =>
+      'MemoryTimelineSample(ts: $timestamp, heap: $heapUsed, rss: $rss)';
+}

--- a/test/helpers/test_mocks.dart
+++ b/test/helpers/test_mocks.dart
@@ -6,6 +6,8 @@ class FakeVmService extends VmService {
   final Map<String, Map<String, dynamic>> serviceExtensionResponses = {};
   final StreamController<Event> _eventController =
       StreamController<Event>.broadcast();
+  final StreamController<Event> _gcEventController =
+      StreamController<Event>.broadcast();
 
   bool disposeCalled = false;
   int allocationProfileCalls = 0;
@@ -13,6 +15,7 @@ class FakeVmService extends VmService {
   bool timelineCleared = false;
   Map<String, dynamic>? lastArgs;
   String? lastExtensionCalled;
+  List<String> activeStreamSubscriptions = [];
 
   List<String> mockExtensionRPCs = [];
   Map<String, dynamic> mockTimelineResponse = {};
@@ -22,8 +25,19 @@ class FakeVmService extends VmService {
   @override
   Stream<Event> get onExtensionEvent => _eventController.stream;
 
+  @override
+  Stream<Event> get onGCEvent => _gcEventController.stream;
+
   void emitExtensionEvent(Event event) {
     _eventController.add(event);
+  }
+
+  void emitGcEvent({String gcType = 'Scavenge', int? timestamp}) {
+    _gcEventController.add(Event(
+      kind: 'GC',
+      timestamp: timestamp ?? DateTime.now().millisecondsSinceEpoch,
+      gcType: gcType,
+    ));
   }
 
   void emitRebuildEvent(Map<String, dynamic> data) {
@@ -33,6 +47,44 @@ class FakeVmService extends VmService {
       extensionKind: 'Flutter.RebuiltWidgets',
       extensionData: ExtensionData.parse(data),
     ));
+  }
+
+  @override
+  Future<Success> streamListen(String streamId) async {
+    if (activeStreamSubscriptions.contains(streamId)) {
+      throw RPCError('streamListen', 103, 'Stream already subscribed');
+    }
+    activeStreamSubscriptions.add(streamId);
+    return Success();
+  }
+
+  @override
+  Future<Success> streamCancel(String streamId) async {
+    activeStreamSubscriptions.remove(streamId);
+    return Success();
+  }
+
+  @override
+  Future<ProcessMemoryUsage> getProcessMemoryUsage() async {
+    return ProcessMemoryUsage(
+      root: ProcessMemoryItem(
+        name: 'Total',
+        description: 'Total process memory',
+        size: 50 * 1024 * 1024,
+        children: [
+          ProcessMemoryItem(
+            name: 'Dart',
+            description: 'Dart heap memory',
+            size: 20 * 1024 * 1024,
+          ),
+          ProcessMemoryItem(
+            name: 'Native',
+            description: 'Native memory',
+            size: 30 * 1024 * 1024,
+          ),
+        ],
+      ),
+    );
   }
 
   @override
@@ -210,6 +262,7 @@ class FakeVmService extends VmService {
   Future<Success> dispose() async {
     disposeCalled = true;
     await _eventController.close();
+    await _gcEventController.close();
     return Success();
   }
 }

--- a/test/tools/server_test.dart
+++ b/test/tools/server_test.dart
@@ -15,6 +15,10 @@ class FakeVmService extends VmService {
   RPCError? Function(String method)? customServiceExtensionError;
   Object? Function(String expression)? customEvaluateError;
 
+  final StreamController<Event> _gcEventController =
+      StreamController<Event>.broadcast();
+  List<String> activeStreamSubscriptions = [];
+
   FakeVmService()
       : super(
           const Stream<dynamic>.empty(),
@@ -23,6 +27,55 @@ class FakeVmService extends VmService {
 
   @override
   Stream<Event> get onExtensionEvent => const Stream<Event>.empty();
+
+  @override
+  Stream<Event> get onGCEvent => _gcEventController.stream;
+
+  void emitGcEvent({String gcType = 'Scavenge', int? timestamp}) {
+    _gcEventController.add(Event(
+      kind: 'GC',
+      timestamp: timestamp ?? DateTime.now().millisecondsSinceEpoch,
+      gcType: gcType,
+    ));
+  }
+
+  @override
+  Future<Success> streamListen(String streamId) async {
+    if (activeStreamSubscriptions.contains(streamId)) {
+      throw RPCError('streamListen', 103, 'Stream already subscribed');
+    }
+    activeStreamSubscriptions.add(streamId);
+    return Success();
+  }
+
+  @override
+  Future<Success> streamCancel(String streamId) async {
+    activeStreamSubscriptions.remove(streamId);
+    return Success();
+  }
+
+  @override
+  Future<ProcessMemoryUsage> getProcessMemoryUsage() async {
+    return ProcessMemoryUsage(
+      root: ProcessMemoryItem(
+        name: 'Total',
+        description: 'Total process memory',
+        size: 50 * 1024 * 1024,
+        children: [
+          ProcessMemoryItem(
+            name: 'Dart',
+            description: 'Dart heap memory',
+            size: 20 * 1024 * 1024,
+          ),
+          ProcessMemoryItem(
+            name: 'Native',
+            description: 'Native memory',
+            size: 30 * 1024 * 1024,
+          ),
+        ],
+      ),
+    );
+  }
 
   @override
   Future<Response> callServiceExtension(
@@ -369,6 +422,123 @@ void main() {
       final text = (result.content.first as TextContent).text;
       expect(text, contains('+1.46 KB')); // 1500 bytes diff
       expect(text, contains('+5'));
+    });
+
+    test('memory force_gc triggers GC and reports heap changes', () async {
+      server.vmService = fakeVmService;
+      server.isolateId = 'isolate_1';
+      server.vmServiceUri = 'ws://127.0.0.1:8181/auth_token/ws';
+
+      final result = await server.callTool(
+        CallToolRequest(
+          name: McpTool.memory.name,
+          arguments: const {
+            'action': 'force_gc',
+          },
+        ),
+      );
+
+      expect(result.isError, isNot(isTrue));
+      final text = (result.content.first as TextContent).text;
+      expect(text, contains('Garbage Collection'));
+      expect(text, contains('Before'));
+      expect(text, contains('After'));
+    });
+
+    test('memory start_gc_stream and stop_gc_stream lifecycle', () async {
+      server.vmService = fakeVmService;
+      server.isolateId = 'isolate_1';
+      server.vmServiceUri = 'ws://127.0.0.1:8181/auth_token/ws';
+
+      final startResult = await server.callTool(
+        CallToolRequest(
+          name: McpTool.memory.name,
+          arguments: const {
+            'action': 'start_gc_stream',
+          },
+        ),
+      );
+      expect(startResult.isError, isNot(isTrue));
+      expect((startResult.content.first as TextContent).text,
+          contains('GC Stream Monitoring Started'));
+
+      fakeVmService.emitGcEvent();
+
+      final stopResult = await server.callTool(
+        CallToolRequest(
+          name: McpTool.memory.name,
+          arguments: const {
+            'action': 'stop_gc_stream',
+          },
+        ),
+      );
+      expect(stopResult.isError, isNot(isTrue));
+      expect((stopResult.content.first as TextContent).text,
+          contains('GC Stream Monitoring Stopped'));
+    });
+
+    test('memory get_memory_timeline samples memory usage', () async {
+      server.vmService = fakeVmService;
+      server.isolateId = 'isolate_1';
+      server.vmServiceUri = 'ws://127.0.0.1:8181/auth_token/ws';
+
+      final result = await server.callTool(
+        CallToolRequest(
+          name: McpTool.memory.name,
+          arguments: const {
+            'action': 'get_memory_timeline',
+            'duration_seconds': 1,
+          },
+        ),
+      );
+
+      expect(result.isError, isNot(isTrue));
+      final text = (result.content.first as TextContent).text;
+      expect(text, contains('Memory Timeline'));
+      expect(text, contains('Heap Used'));
+    });
+
+    test('memory watch_gc_pressure assesses pressure level', () async {
+      server.vmService = fakeVmService;
+      server.isolateId = 'isolate_1';
+      server.vmServiceUri = 'ws://127.0.0.1:8181/auth_token/ws';
+
+      final result = await server.callTool(
+        CallToolRequest(
+          name: McpTool.memory.name,
+          arguments: const {
+            'action': 'watch_gc_pressure',
+            'duration_seconds': 1,
+          },
+        ),
+      );
+
+      expect(result.isError, isNot(isTrue));
+      final text = (result.content.first as TextContent).text;
+      expect(text, contains('GC Pressure Analysis'));
+      expect(text, contains('Pressure Level'));
+    });
+
+    test('memory explain_memory_breakdown returns detailed breakdown',
+        () async {
+      server.vmService = fakeVmService;
+      server.isolateId = 'isolate_1';
+      server.vmServiceUri = 'ws://127.0.0.1:8181/auth_token/ws';
+
+      final result = await server.callTool(
+        CallToolRequest(
+          name: McpTool.memory.name,
+          arguments: const {
+            'action': 'explain_memory_breakdown',
+          },
+        ),
+      );
+
+      expect(result.isError, isNot(isTrue));
+      final text = (result.content.first as TextContent).text;
+      expect(text, contains('Memory Usage Breakdown'));
+      expect(text, contains('Resident Set Size (RSS)'));
+      expect(text, contains('Dart Heap'));
     });
 
     test('profiling get_cpu scans execution hotspots', () async {

--- a/test/tools/server_test.dart
+++ b/test/tools/server_test.dart
@@ -541,6 +541,164 @@ void main() {
       expect(text, contains('Dart Heap'));
     });
 
+    test(
+        'memory start_gc_stream called twice handles RPCError 103 idempotently',
+        () async {
+      server.vmService = fakeVmService;
+      server.isolateId = 'isolate_1';
+      server.vmServiceUri = 'ws://127.0.0.1:8181/auth_token/ws';
+
+      final res1 = await server.callTool(
+        CallToolRequest(
+          name: McpTool.memory.name,
+          arguments: const {'action': 'start_gc_stream'},
+        ),
+      );
+      expect(res1.isError, isNot(isTrue));
+
+      // Calling start_gc_stream again when stream is already subscribed
+      final res2 = await server.callTool(
+        CallToolRequest(
+          name: McpTool.memory.name,
+          arguments: const {'action': 'start_gc_stream'},
+        ),
+      );
+      expect(res2.isError, isNot(isTrue));
+
+      // Cleanup
+      await server.callTool(
+        CallToolRequest(
+          name: McpTool.memory.name,
+          arguments: const {'action': 'stop_gc_stream'},
+        ),
+      );
+    });
+
+    test(
+        'memory stop_gc_stream when not started returns empty events gracefully',
+        () async {
+      server.vmService = fakeVmService;
+      server.isolateId = 'isolate_1';
+      server.vmServiceUri = 'ws://127.0.0.1:8181/auth_token/ws';
+
+      final result = await server.callTool(
+        CallToolRequest(
+          name: McpTool.memory.name,
+          arguments: const {'action': 'stop_gc_stream'},
+        ),
+      );
+
+      expect(result.isError, isNot(isTrue));
+      final text = (result.content.first as TextContent).text;
+      expect(text, contains('Total Events Captured**: 0'));
+    });
+
+    test('memory stop_gc_stream respects limit parameter', () async {
+      server.vmService = fakeVmService;
+      server.isolateId = 'isolate_1';
+      server.vmServiceUri = 'ws://127.0.0.1:8181/auth_token/ws';
+
+      await server.callTool(
+        CallToolRequest(
+          name: McpTool.memory.name,
+          arguments: const {'action': 'start_gc_stream'},
+        ),
+      );
+
+      // Emit 5 events
+      for (var i = 0; i < 5; i++) {
+        fakeVmService.emitGcEvent();
+      }
+      await Future<void>.delayed(Duration.zero);
+
+      final result = await server.callTool(
+        CallToolRequest(
+          name: McpTool.memory.name,
+          arguments: const {
+            'action': 'stop_gc_stream',
+            'limit': 2,
+          },
+        ),
+      );
+
+      expect(result.isError, isNot(isTrue));
+      final text = (result.content.first as TextContent).text;
+      expect(text, contains('Events Returned**: 2'));
+    });
+
+    test('memory get_memory_timeline clamps negative or excessive duration',
+        () async {
+      server.vmService = fakeVmService;
+      server.isolateId = 'isolate_1';
+      server.vmServiceUri = 'ws://127.0.0.1:8181/auth_token/ws';
+
+      final result = await server.callTool(
+        CallToolRequest(
+          name: McpTool.memory.name,
+          arguments: const {
+            'action': 'get_memory_timeline',
+            'duration_seconds': -10, // Clamped to 1s
+          },
+        ),
+      );
+
+      expect(result.isError, isNot(isTrue));
+      final text = (result.content.first as TextContent).text;
+      expect(text, contains('Memory Timeline (1s recording)'));
+    });
+
+    test('memory watch_gc_pressure categorizes pressure levels correctly',
+        () async {
+      server.vmService = fakeVmService;
+      server.isolateId = 'isolate_1';
+      server.vmServiceUri = 'ws://127.0.0.1:8181/auth_token/ws';
+
+      final result = await server.callTool(
+        CallToolRequest(
+          name: McpTool.memory.name,
+          arguments: const {
+            'action': 'watch_gc_pressure',
+            'duration_seconds': 1,
+            'limit': 10,
+          },
+        ),
+      );
+
+      expect(result.isError, isNot(isTrue));
+      final text = (result.content.first as TextContent).text;
+      expect(text, contains('Pressure Level**: `LOW`'));
+    });
+
+    test(
+        'memory explain_memory_breakdown handles raster cache extension failure gracefully',
+        () async {
+      server.vmService = fakeVmService;
+      server.isolateId = 'isolate_1';
+      server.vmServiceUri = 'ws://127.0.0.1:8181/auth_token/ws';
+
+      fakeVmService.customServiceExtensionError = (method) {
+        if (method == 'ext.ui.window.getSkiaEstimateRasterCacheMemory') {
+          return RPCError('callServiceExtension', -32601, 'Method not found');
+        }
+        return null;
+      };
+
+      final result = await server.callTool(
+        CallToolRequest(
+          name: McpTool.memory.name,
+          arguments: const {
+            'action': 'explain_memory_breakdown',
+          },
+        ),
+      );
+
+      expect(result.isError, isNot(isTrue));
+      final text = (result.content.first as TextContent).text;
+      expect(text, contains('Raster Cache**: N/A'));
+
+      fakeVmService.customServiceExtensionError = null;
+    });
+
     test('profiling get_cpu scans execution hotspots', () async {
       server.vmService = fakeVmService;
       server.isolateId = 'isolate_1';

--- a/test/unit/memory_timeline_models_test.dart
+++ b/test/unit/memory_timeline_models_test.dart
@@ -1,0 +1,75 @@
+import 'package:flutter_agent_lens/src/models/memory_models.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('MemoryTimelineSample Tests', () {
+    test('fromMap and toMap round-trip', () {
+      final json = {
+        'timestamp': 1717171717,
+        'heap_used': 5000000,
+        'heap_capacity': 10000000,
+        'external_usage': 1000000,
+        'rss': 25000000,
+        'gc_events_in_interval': 2,
+      };
+
+      final sample = MemoryTimelineSample.fromMap(json);
+      expect(sample.timestamp, equals(1717171717));
+      expect(sample.heapUsed, equals(5000000));
+      expect(sample.heapCapacity, equals(10000000));
+      expect(sample.externalUsage, equals(1000000));
+      expect(sample.rss, equals(25000000));
+      expect(sample.gcEventsInInterval, equals(2));
+
+      final mapped = sample.toMap();
+      expect(mapped, equals(json));
+    });
+
+    test('equality and hashCode', () {
+      const sample1 = MemoryTimelineSample(
+        timestamp: 1000,
+        heapUsed: 500,
+        heapCapacity: 1000,
+        externalUsage: 100,
+        rss: 2000,
+        gcEventsInInterval: 1,
+      );
+
+      const sample2 = MemoryTimelineSample(
+        timestamp: 1000,
+        heapUsed: 500,
+        heapCapacity: 1000,
+        externalUsage: 100,
+        rss: 2000,
+        gcEventsInInterval: 1,
+      );
+
+      const sampleDifferent = MemoryTimelineSample(
+        timestamp: 2000,
+        heapUsed: 500,
+        heapCapacity: 1000,
+        externalUsage: 100,
+        rss: 2000,
+        gcEventsInInterval: 1,
+      );
+
+      expect(sample1, equals(sample2));
+      expect(sample1.hashCode, equals(sample2.hashCode));
+      expect(sample1, isNot(equals(sampleDifferent)));
+    });
+
+    test('toString representation', () {
+      const sample = MemoryTimelineSample(
+        timestamp: 1000,
+        heapUsed: 500,
+        heapCapacity: 1000,
+        externalUsage: 100,
+        rss: 2000,
+        gcEventsInInterval: 1,
+      );
+      expect(sample.toString(), contains('1000'));
+      expect(sample.toString(), contains('500'));
+      expect(sample.toString(), contains('2000'));
+    });
+  });
+}


### PR DESCRIPTION
Fixes #8

## Changes

Adds 6 memory tool actions to the `memory` composite tool:

1. `force_gc`: Triggers GC on the target isolate and returns freed memory, capacity, usage, and external memory metrics.
2. `start_gc_stream`: Subscribes to `EventStreams.kGC` to capture VM Service GC events.
3. `stop_gc_stream`: Unsubscribes from the GC stream and returns buffered GC events (`Scavenge`, `MarkSweep`, `StartCMark`) with timestamps.
4. `get_memory_timeline`: Records periodic memory usage samples (Heap Used, Capacity, External Memory, Process RSS, GC event count per interval) over 1–60 seconds.
5. `watch_gc_pressure`: Tracks GC frequency, calculates average inter-GC intervals, and categorizes memory pressure (`LOW`, `MODERATE`, `HIGH`).
6. `explain_memory_breakdown`: Reports Resident Set Size (RSS), Dart Heap, External Memory, and Skia Raster Cache memory metrics.

## Technical Details

- **Model**: Added `MemoryTimelineSample` model with `fromMap`, `toMap`, `==`, `hashCode`, and `toString`.
- **Refactoring**:
  - `_getHeapStats()`: Centralized heap statistics extraction from `AllocationProfile`.
  - `_getRssBytes()`: Centralized process memory RSS reading from `getProcessMemoryUsage()`.
- **Stream Lifecycle & RPC Handling**:
  - `cleanupMemoryDebugging()` cancels active GC stream subscriptions.
  - Catches `RPCError` code 103 for idempotent `streamListen` calls.
- **Raster Cache**: Falls back gracefully when `ext.ui.window.getSkiaEstimateRasterCacheMemory` is unavailable.

## Verification

- **Unit Tests**: Added 3 unit tests in `test/unit/memory_timeline_models_test.dart`.
- **Integration Tests**: Added 11 integration tests in `test/tools/server_test.dart` for action handlers, stream lifecycle, limit parameters, duration clamping, pressure levels, and fallbacks.
- **Suite Results**:
  - `dart test`: 140 / 140 tests passing.
  - `dart analyze`: 0 issues found.
- **Live Test**: Executed 6 tool actions against a running Flutter application with 6/6 successful calls.

## Documentation

- Updated `README.md` tool catalog.
- Updated `CHANGELOG.md` under `## Unreleased`.
