### PR TITLE
docs(github): add GitHub PR template and YAML Issue Forms for bugs and features

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: Bug Report
+description: Report a problem or unexpected behavior in flutter_agent_lens
+title: "[BUG]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for taking the time to report a bug! Please search existing issues first to avoid duplicates.
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: Provide a clear and concise description of what the bug is.
+      placeholder: Describe the problem...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. Connect flutter_agent_lens to Flutter VM Service...
+        2. Run tool action '...'
+        3. See error...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: A clear description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment Details
+      description: OS version, Dart/Flutter version (`flutter doctor`), and IDE context.
+      placeholder: |
+        - OS: macOS 14.5
+        - Flutter Version: 3.22.0
+        - Dart SDK: 3.4.0
+        - Connection Mode: VM Service WebSocket
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant Logs or Error Output
+      description: Copy and paste stderr diagnostic output or stack traces if available.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Discussions
+    url: https://github.com/dhruvanbhalara/flutter_agent_lens/discussions
+    about: Please ask questions or discuss ideas here instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,32 @@
+name: Feature Request
+description: Suggest an idea, new MCP tool, or improvement for flutter_agent_lens
+title: "[FEAT]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: Thank you for suggesting a feature! Please describe the use case clearly.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem?
+      description: Provide a clear and concise description of the problem or limitation (e.g. "I'm always frustrated when...").
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution or new MCP tool / action capability you would like to see.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Describe any alternative solutions or workarounds you have considered.
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Add any other context, screenshots, or MCP client usage patterns (e.g. Antigravity, Cursor, Claude).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!-- PR Title Guide: Please follow Conventional Commits format: feat(scope): title, fix(scope): title, refactor(scope): title, docs(scope): title -->
+
+## Description
+
+<!-- Provide a concise summary of the change and link any relevant issue (e.g. Closes #123). -->
+
+## Key Impact & Capabilities
+
+<!-- Describe user-facing improvements, behavioral changes, or API updates. -->
+
+## How Has This Been Tested?
+
+- [ ] `dart test` (Unit and integration test suite passes)
+- [ ] `dart analyze` (Zero static analysis warnings)
+- [ ] Manual verification with a running Flutter application
+
+## Pre-Merge Checklist
+
+- [ ] PR title follows Conventional Commits specification (`feat:`, `fix:`, `refactor:`, `docs:`, `perf:`).
+- [ ] Code follows project formatting guidelines (`dart format .`).
+- [ ] All automated tests pass locally.


### PR DESCRIPTION
## Description

Adds production-grade GitHub PR template and interactive YAML Issue Forms (`bug_report.yml`, `feature_request.yml`, `config.yml`) following open-source standards and Conventional Commits PR title guidelines.

## Key Capabilities

- **PR Template (`.github/PULL_REQUEST_TEMPLATE.md`)**: Enforces Conventional Commits title structure and pre-merge validation checklists (`dart test`, `dart analyze`, `dart format .`).
- **Bug Report Form (`.github/ISSUE_TEMPLATE/bug_report.yml`)**: Interactive form collecting `flutter doctor` environment info, connection mode, and steps to reproduce with automatic `bug` label.
- **Feature Request Form (`.github/ISSUE_TEMPLATE/feature_request.yml`)**: Structured form for problem/solution feature proposals with automatic `enhancement` label.
- **Issue Chooser Config (`.github/ISSUE_TEMPLATE/config.yml`)**: Disables blank issues and directs general questions to Discussions.

## Verification

- Tested YAML syntax and GitHub template path requirements.
- Ran full test suite (`145/145 tests passed`) and static analysis (`0 warnings/errors`).