### PR TITLE
fix(memory): prevent VM Service RPC queue starvation in audit_leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.7.3
+
+### Fixed
+- Fixed VM Service connection hangs during memory leak audits on classes with large instance counts.
+- Fixed evaluation crashes when auditing memory leaks on non-State objects.
+
 ## 1.7.2
 
 ### Added

--- a/lib/flutter_agent_lens.dart
+++ b/lib/flutter_agent_lens.dart
@@ -45,7 +45,7 @@ final class FlutterAgentLensServer extends MCPServer
           channel,
           implementation: Implementation(
             name: 'flutter_agent_lens',
-            version: '1.7.2',
+            version: '1.7.3',
           ),
           instructions: 'A tool server to interact with running Flutter apps. '
               'Connect using the connect tool, or discover running apps with discover_apps.',

--- a/lib/src/mixins/memory_debugging_support.dart
+++ b/lib/src/mixins/memory_debugging_support.dart
@@ -217,26 +217,27 @@ base mixin MemoryDebuggingSupport
     final reports = <Map<String, dynamic>>[];
     final mdBuffer = StringBuffer();
 
-    final mountedResults = await Future.wait(
-      instances.map((instanceRef) async {
-        final instanceId = instanceRef.id;
-        if (instanceId == null) {
-          return (instanceId: null, isMounted: true);
-        }
-        try {
-          final evalResult = await vmService!.evaluate(
-            isolateId!,
-            instanceId,
-            'this.mounted',
-          );
-          final isMounted =
-              evalResult is InstanceRef && evalResult.valueAsString == 'true';
-          return (instanceId: instanceId, isMounted: isMounted);
-        } catch (_) {
-          return (instanceId: instanceId, isMounted: true);
-        }
-      }),
-    );
+    // Process mounted evaluations sequentially/chunked to prevent VM Service RPC queue starvation
+    final mountedResults = <({String? instanceId, bool isMounted})>[];
+    for (final instanceRef in instances) {
+      final instanceId = instanceRef.id;
+      if (instanceId == null) {
+        mountedResults.add((instanceId: null, isMounted: true));
+        continue;
+      }
+      try {
+        final evalResult = await vmService!.evaluate(
+          isolateId!,
+          instanceId,
+          'this is State ? (this as dynamic).mounted : true',
+        );
+        final isMounted =
+            evalResult is InstanceRef && evalResult.valueAsString == 'true';
+        mountedResults.add((instanceId: instanceId, isMounted: isMounted));
+      } catch (_) {
+        mountedResults.add((instanceId: instanceId, isMounted: true));
+      }
+    }
 
     final unmountedInstances = mountedResults
         .where((r) => r.instanceId != null && !r.isMounted)
@@ -244,35 +245,34 @@ base mixin MemoryDebuggingSupport
         .toList();
 
     if (unmountedInstances.isNotEmpty) {
-      final retainingPathResults = await Future.wait(
-        unmountedInstances.map((instanceId) async {
-          try {
-            final retainingPath =
-                await vmService!.getRetainingPath(isolateId!, instanceId, 15);
-            final pathElements = <String>[];
-            final elements = retainingPath.elements ?? [];
-            for (final element in elements.whereType<RetainingObject>()) {
-              final val = element.value;
-              if (val is InstanceRef) {
-                pathElements.add('${val.classRef?.name} (${val.id})');
-              } else {
-                pathElements.add(val.toString());
-              }
+      final retainingPathResults = <Map<String, dynamic>>[];
+      for (final instanceId in unmountedInstances) {
+        try {
+          final retainingPath =
+              await vmService!.getRetainingPath(isolateId!, instanceId, 15);
+          final pathElements = <String>[];
+          final elements = retainingPath.elements ?? [];
+          for (final element in elements.whereType<RetainingObject>()) {
+            final val = element.value;
+            if (val is InstanceRef) {
+              pathElements.add('${val.classRef?.name} (${val.id})');
+            } else {
+              pathElements.add(val.toString());
             }
-            return {
-              'instance_id': instanceId,
-              'mounted': false,
-              'retaining_path': pathElements,
-            };
-          } catch (e) {
-            return {
-              'instance_id': instanceId,
-              'mounted': false,
-              'retaining_path': ['Error retrieving retaining path: $e'],
-            };
           }
-        }),
-      );
+          retainingPathResults.add({
+            'instance_id': instanceId,
+            'mounted': false,
+            'retaining_path': pathElements,
+          });
+        } catch (e) {
+          retainingPathResults.add({
+            'instance_id': instanceId,
+            'mounted': false,
+            'retaining_path': ['Error retrieving retaining path: $e'],
+          });
+        }
+      }
       reports.addAll(retainingPathResults);
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_agent_lens
 description: Agent-first MCP server to debug, profile, and optimize running Flutter apps.
-version: 1.7.2
+version: 1.7.3
 homepage: https://github.com/dhruvanbhalara/flutter_agent_lens
 repository: https://github.com/dhruvanbhalara/flutter_agent_lens
 


### PR DESCRIPTION
## Description

Fixes VM Service connection hangs and socket starvation during `memory` tool leak audits on classes with large instance counts. Also adds runtime evaluation type-safety guards for non-`State` instance references. Bumps package version to `1.7.3`.

## Key Impact & Capabilities

- **RPC Queue Starvation Fix**: Evaluates `.mounted` states and retaining paths sequentially during `audit_leak` operations, preventing VM Service socket queue starvation when inspecting large instance sets.
- **State Mounted Safety Guard**: Guards mounted evaluation with `this is State ? (this as dynamic).mounted : true` to prevent evaluation crashes on non-`State` objects.
- **Version Release**: Bumps package version to `1.7.3` and records user-facing fixes in `CHANGELOG.md`.

## How Has This Been Tested?

- [x] `dart test` (Unit and integration test suite passes)
- [x] `dart analyze` (Zero static analysis warnings)
- [ ] Manual verification with a running Flutter application

## Pre-Merge Checklist

- [x] PR title follows Conventional Commits specification (`feat:`, `fix:`, `refactor:`, `docs:`, `perf:`).
- [x] Code follows project formatting guidelines (`dart format .`).
- [x] All automated tests pass locally.
