### PR TITLE
chore(release): bump version to 1.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+## 1.7.4
 
 ### Fixed
 - Fixed unhandled crashes and null reference errors when the VM service disconnects during active tool execution.

--- a/lib/flutter_agent_lens.dart
+++ b/lib/flutter_agent_lens.dart
@@ -45,7 +45,7 @@ final class FlutterAgentLensServer extends MCPServer
           channel,
           implementation: Implementation(
             name: 'flutter_agent_lens',
-            version: '1.7.3',
+            version: '1.7.4',
           ),
           instructions: 'A tool server to interact with running Flutter apps. '
               'Connect using the connect tool, or discover running apps with discover_apps.',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_agent_lens
 description: Agent-first MCP server to debug, profile, and optimize running Flutter apps.
-version: 1.7.3
+version: 1.7.4
 homepage: https://github.com/dhruvanbhalara/flutter_agent_lens
 repository: https://github.com/dhruvanbhalara/flutter_agent_lens
 


### PR DESCRIPTION
## Description

Bumps the package and MCP server implementation version from `1.7.3` to `1.7.4` and updates `CHANGELOG.md` to document all bug fixes and stability improvements included in this patch release.

## Key Impact & Capabilities

- **Version Bump**: Updates `pubspec.yaml` and `FlutterAgentLensServer` implementation metadata to `1.7.4`.
- **Changelog Promotion**: Promoted `## [Unreleased]` entries to `## 1.7.4`:
  - Fixed unhandled crashes and null reference errors when the VM service disconnects during active tool execution.
  - Fixed a memory leak where background disconnect listeners remained attached after sampling completed.
  - Prevented inaccurate GC monitoring state from showing active when disconnected from the VM service.

## How Has This Been Tested?

- [x] `dart test` (Unit and integration test suite passes)
- [x] `dart analyze` (Zero static analysis warnings)
- [ ] Manual verification with a running Flutter application

## Pre-Merge Checklist

- [x] PR title follows Conventional Commits specification (`feat:`, `fix:`, `refactor:`, `docs:`, `perf:`, `chore:`).
- [x] Code follows project formatting guidelines (`dart format .`).
- [x] All automated tests pass locally.